### PR TITLE
Fixed Issue #3

### DIFF
--- a/after/plugin/boardopen.vim
+++ b/after/plugin/boardopen.vim
@@ -2,5 +2,5 @@
 function! JiraVimBoardOpen(name)
     echom "Loading board " . a:name
     execute "python3 sys.argv = [\"" . a:name . "\"]"
-    execute "python3 python.boards.open.JiraVimBoardOpen()"
+    execute "python3 python.boards.open.JiraVimBoardOpen(sessionStorage)"
 endfunction

--- a/after/plugin/issueopen.vim
+++ b/after/plugin/issueopen.vim
@@ -2,5 +2,5 @@
 function! JiraVimIssueOpen(name)
     echom "Loading issue " . a:name
     execute "python3 sys.argv = [\"" . a:name . "\"]"
-    execute "python3 python.issues.open.JiraVimIssueOpen()"
+    execute "python3 python.issues.open.JiraVimIssueOpen(sessionStorage)"
 endfunction

--- a/ftplugin/jiraboardview.vim
+++ b/ftplugin/jiraboardview.vim
@@ -1,6 +1,5 @@
 
 setl buftype=nofile
-setl noswapfile
 setl nomodifiable
 normal! gg
 

--- a/ftplugin/jiraissueview.vim
+++ b/ftplugin/jiraissueview.vim
@@ -1,6 +1,5 @@
 
 setl buftype=nofile
-setl noswapfile
 setl nomodifiable
 normal! gg
 

--- a/plugin/setup.vim
+++ b/plugin/setup.vim
@@ -3,8 +3,16 @@
 let s:python_dir = expand("<sfile>:p:h") . "/"
 execute "python3 import sys"
 execute "python3 sys.path.append('" . s:python_dir . "../')"
-execute "python3 import python.boards.open"
-execute "python3 import python.issues.open"
+python3 from python.common.sessionObject import SessionObject
 
+python3 << EOF
+sessionStorage = SessionObject()
+EOF
+
+" Import all scripts with functions here
+python3 import python.boards.open
+python3 import python.issues.open
+
+" Expand runtime path to the after/plugin/ directory
 let s:addRuntimePath = expand("<sfile>:p:h")."/../after/"
 let &runtimepath.=",".s:addRuntimePath

--- a/python/boards/open.py
+++ b/python/boards/open.py
@@ -3,43 +3,50 @@ import sys
 from ..common.connection import Connection
 from ..common.kanbanBoard import KanbanBoard
 
-connection = Connection.getConnectionFromVars()
 
 # arguments expected in sys.argv
-def JiraVimBoardOpen():
+def JiraVimBoardOpen(sessionStorage):
     boardName = str( sys.argv[0]) 
+    connection = sessionStorage.connection 
     board = connection.getBoard(boardName)
     issues = board.getIssues()
-
-    # Buff Setup Commands
-    vim.command("new")
-
-    buf = vim.current.buffer
-    buf[0] = boardName + " BOARD"
-    buf.append("="*( len(boardName)+7 ) )
-    buf.append("")
-    textWidth = vim.current.window.width
-
-    # Print the issues by category
-    for cat in issues:
-        buf.append(cat[0].upper()+":")
-        buf.append("-"*( len(cat[0])+1 ))
-        startLine = len(buf)+1
-        i = cat[1]
-        endLine = startLine + len(i)-1
-        maxKeyLen = 0
-        maxSummLen = 0
-        for key, summ in i:
-            if len(key) >= maxKeyLen:
-                maxKeyLen = len(key)
-            if len(summ) >= maxSummLen:
-                maxSummLen = len(summ)
-            buf.append(key + " " + summ)
-        vim.command("%d,%dTabularize /\\u\+-\d\+\s/r0l%dr0" % ( startLine, endLine, textWidth-maxKeyLen-maxSummLen-7))
-        buf.append("")
 
     if isinstance(board, KanbanBoard):
         filetype = "jirakanbanboardview"
     else:
         filetype = "jiraboardview"
-    vim.command("setl filetype=%s" % filetype)
+
+    # Buff Setup Commands
+    buf, new = sessionStorage.getBuff(objName=boardName)
+    if new:
+        sessionStorage.assignBoard(board, buf)
+        buf[0] = boardName + " BOARD"
+        buf.append("="*( len(boardName)+7 ) )
+        buf.append("")
+        textWidth = vim.current.window.width
+
+        # Print the issues by category
+        for cat in issues:
+            buf.append(cat[0].upper()+":")
+            buf.append("-"*( len(cat[0])+1 ))
+            startLine = len(buf)+1
+            i = cat[1]
+            endLine = startLine + len(i)-1
+            maxKeyLen = 0
+            maxSummLen = 0
+            for key, summ in i:
+                if len(key) >= maxKeyLen:
+                    maxKeyLen = len(key)
+                if len(summ) >= maxSummLen:
+                    maxSummLen = len(summ)
+                buf.append(key + " " + summ)
+            vim.command("%d,%dTabularize /\\u\+-\d\+\s/r0l%dr0" % ( startLine, endLine, textWidth-maxKeyLen-maxSummLen-7))
+            buf.append("")
+            
+
+        vim.command("setl filetype=%s" % filetype)
+    else:
+        # Open the buffer in the current window
+        # TODO: Have a global variable control whether the issue is opened inthe current window or a check will happen if it's already opened
+        vim.command("buf "+str(buf.number))
+         

--- a/python/boards/open.py
+++ b/python/boards/open.py
@@ -47,6 +47,6 @@ def JiraVimBoardOpen(sessionStorage):
         vim.command("setl filetype=%s" % filetype)
     else:
         # Open the buffer in the current window
-        # TODO: Have a global variable control whether the issue is opened inthe current window or a check will happen if it's already opened
+        # TODO: Have a global variable control whether the issue is opened in the current window or a check will happen if it's already opened
         vim.command("buf "+str(buf.number))
          

--- a/python/common/board.py
+++ b/python/common/board.py
@@ -1,9 +1,10 @@
 import json
 
 class Board:
-    def __init__(self, boardId, connection):
+    def __init__(self, boardId, boardName, connection):
         self.connection = connection
         self.boardId = boardId
+        self.boardName = boardName
         self.baseUrl = "/rest/agile/1.0/board/"+boardId
         self.requiredProperties = ["key", "status", "summary"] 
 

--- a/python/common/connection.py
+++ b/python/common/connection.py
@@ -39,9 +39,9 @@ class Connection:
             boardType = self.__boardHash[boardName]["type"]
             boardId = str(self.__boardHash[boardName]["id"])
             if boardType == "type":
-                return Board(boardId, self)
+                return Board(boardId, boardName, self)
             else:
-                return KanbanBoard(boardId, self)
+                return KanbanBoard(boardId, boardName, self)
         else:
             return None 
 
@@ -51,11 +51,3 @@ class Connection:
     def customRequest(self, request):
         reqStr = self.__baseUrl + request
         return requests.get(reqStr, auth=(self.__email, self.__token))
-
-    @staticmethod
-    def getConnectionFromVars():
-        domainName = vim.vars["jiraVimDomainName"].decode("utf-8")
-        email = vim.vars["jiraVimEmail"].decode("utf-8")
-        token = vim.vars["jiraVimToken"].decode("utf-8")
-
-        return Connection(domainName, email, token)

--- a/python/common/kanbanBoard.py
+++ b/python/common/kanbanBoard.py
@@ -2,8 +2,8 @@ from .board import Board
 import json
 
 class KanbanBoard(Board):
-    def __init__(self, boardId, connection):
-        Board.__init__(self, boardId, connection)
+    def __init__(self, boardId, boardName, connection):
+        Board.__init__(self, boardId, boardName, connection)
         
         # Populate the status sets
         boardConf = self.connection.customRequest(self.baseUrl+"/configuration")  .json()

--- a/python/common/sessionObject.py
+++ b/python/common/sessionObject.py
@@ -1,0 +1,54 @@
+
+from .connection import Connection
+import vim
+
+class SessionObject():
+    def __init__(self):
+        self.connection = self.getConnectionFromVars()
+
+        # When retrieving buffers, we need to make sure that the buffer is valid. If the buffer is cleared or wiped, it will be marked invalid and we can't retriev it again.
+        self.__bufferHash = {}
+        self.__namesToIds = {}
+
+    def getConnectionFromVars(self):
+        domainName = vim.vars["jiraVimDomainName"].decode("utf-8")
+        email = vim.vars["jiraVimEmail"].decode("utf-8")
+        token = vim.vars["jiraVimToken"].decode("utf-8")
+
+        return Connection(domainName, email, token)
+
+    def assignBoard(self, board, buff):
+        self.__bufferHash[board.boardId] = buff
+        self.__namesToIds[board.boardName] = board.boardId
+
+    def assignIssue(self, issue, buff):
+        self.__bufferHash[issue.id] = buff
+        self.__namesToIds[issue.issueKey] = issue.id
+
+    def getBufferById(self, key):
+        if key in self.__bufferHash:
+            buff = self.__bufferHash[key]
+            return buff if buff.valid else None
+        elif key in self.__namesToIds:
+            buff = self.__bufferHash[self.__namesToIds[key]] 
+            return buff if buff.valid else None
+        else:
+            return None
+
+    # Returns the buffer, and a boolean that says whether the buffer is newly created or existing one
+    def getBuff(self, objId=None, objName=None) :
+        if objId is not None:
+            buff = self.getBufferById(objId)
+            if buff is not None:
+                return ( buff, False )
+        if objName is not None:
+            buff = self.getBufferById(objName)
+            if buff is not None:
+                return ( buff, False )
+        # return new buffer
+        return (self.createBuffer(), True)
+
+    def createBuffer(self):
+        vim.command("new")
+        return vim.current.buffer
+

--- a/python/issues/open.py
+++ b/python/issues/open.py
@@ -4,30 +4,35 @@ from ..common.connection import Connection
 from ..common.issue import Issue
 
 # Arguments are expected through sys.argv
-def JiraVimIssueOpen():
+def JiraVimIssueOpen(sessionStorage):
     issueKey = str(sys.argv[0])
-    connection = Connection.getConnectionFromVars()
+    connection = sessionStorage.connection
     filetype = "jiraissueview"
-    textWidth = vim.current.window.width
 
-    issue = Issue(issueKey, connection)
-    obj = issue.obj
-    project = str( obj.fields.project )
-    summary = obj.fields.summary
-    description = obj.fields.description
+    buf, new = sessionStorage.getBuff(objName=issueKey)
+    if new:
+        textWidth = vim.current.window.width
+        issue = Issue(issueKey, connection)
+        obj = issue.obj
+        project = str( obj.fields.project )
+        summary = obj.fields.summary
+        description = obj.fields.description
 
-    # For now, assume that the this is command is called from an already opened board window
-    buf = vim.current.buffer 
-    buf[:] = None
-    buf[0] = "%s %s" % ( issueKey, project )
-    vim.command("Tabularize /\\u\+-\d\+\s/r0c%dr0" % (textWidth-len(issueKey)-len(project)-7))
-    buf.append("="*len(issueKey))
-    buf.append("")
+        sessionStorage.assignIssue(issue, buf)
 
-    buf.append("Summary: %s" % summary) 
-    buf.append("")
-    
-    buf.append("Description: %s" % description)
-    buf.append("")
-    
-    vim.command("setl filetype=%s" % filetype)
+        # For now, assume that the this is command is called from an already opened board window
+        buf[0] = "%s %s" % ( issueKey, project )
+        vim.command("Tabularize /\\u\+-\d\+\s/r0c%dr0" % (textWidth-len(issueKey)-len(project)-7))
+        buf.append("="*len(issueKey))
+        buf.append("")
+
+        buf.append("Summary: %s" % summary) 
+        buf.append("")
+        
+        buf.append("Description: %s" % description)
+        buf.append("")
+        
+        vim.command("setl filetype=%s" % filetype)
+    else:
+        # Open the buffer in the current window
+        vim.command("buf "+str(buf.number))


### PR DESCRIPTION
## Changes
* Global variable `sessionStorage` that gets passed in to `python.boards.open.JiraVimBoardOpen` and `python.issues.open.JiraVimIssueOpen` as a parameter
* Boards now also need a `boardName` during creation.
* Both opens, for boards and issues (`python.boards.open` and `python.issues.open`), now exhibit previous behavior only when the buffer is new, otherwise they load the buffer for the board and issue into the current window.
* Removed `noswapfile` from the filetypes for boards and issues.

## Notes
* The condition that when you open an issue in a board view it deletes the board view is no longer true. The board is still a valid hidden buffer that can be loaded back if needed.
* We might want to think about how we organize the loading and context switching. I'll make a separate issue for this.