### PR TITLE
Implemented #8

### DIFF
--- a/after/plugin/boardopen.vim
+++ b/after/plugin/boardopen.vim
@@ -4,3 +4,9 @@ function! JiraVimBoardOpen(name)
     execute "python3 sys.argv = [\"" . a:name . "\"]"
     execute "python3 python.boards.open.JiraVimBoardOpen(sessionStorage)"
 endfunction
+
+function! JiraVimBoardOpenNoSp(name)
+    echom "Loading board " . a:name
+    execute "python3 sys.argv = [\"" . a:name . "\"]"
+    execute "python3 python.boards.open.JiraVimBoardOpen(sessionStorage, False)"
+endfunction

--- a/after/plugin/issueopen.vim
+++ b/after/plugin/issueopen.vim
@@ -4,3 +4,9 @@ function! JiraVimIssueOpen(name)
     execute "python3 sys.argv = [\"" . a:name . "\"]"
     execute "python3 python.issues.open.JiraVimIssueOpen(sessionStorage)"
 endfunction
+
+function! JiraVimIssueOpenSp(name)
+    echom "Loading issue " . a:name
+    execute "python3 sys.argv = [\"" . a:name . "\"]"
+    execute "python3 python.issues.open.JiraVimIssueOpen(sessionStorage, True)"
+endfunction

--- a/ftplugin/jiraboardview.vim
+++ b/ftplugin/jiraboardview.vim
@@ -1,5 +1,6 @@
 
 setl buftype=nofile
+setl hidden
 setl nomodifiable
 normal! gg
 

--- a/ftplugin/jiraissueview.vim
+++ b/ftplugin/jiraissueview.vim
@@ -1,5 +1,6 @@
 
 setl buftype=nofile
+setl hidden
 setl nomodifiable
 normal! gg
 

--- a/python/boards/open.py
+++ b/python/boards/open.py
@@ -1,12 +1,11 @@
 import vim
 import sys
-from ..common.connection import Connection
 from ..common.kanbanBoard import KanbanBoard
 
 # arguments expected in sys.argv
 def JiraVimBoardOpen(sessionStorage, isSplit=True):
-    boardName = str( sys.argv[0]) 
-    connection = sessionStorage.connection 
+    boardName = str(sys.argv[0]) 
+    connection = sessionStorage.connection
     board = connection.getBoard(boardName)
     issues = board.getIssues()
 
@@ -48,4 +47,3 @@ def JiraVimBoardOpen(sessionStorage, isSplit=True):
             
 
         vim.command("setl filetype=%s" % filetype)
-

--- a/python/boards/open.py
+++ b/python/boards/open.py
@@ -3,9 +3,8 @@ import sys
 from ..common.connection import Connection
 from ..common.kanbanBoard import KanbanBoard
 
-
 # arguments expected in sys.argv
-def JiraVimBoardOpen(sessionStorage):
+def JiraVimBoardOpen(sessionStorage, isSplit=True):
     boardName = str( sys.argv[0]) 
     connection = sessionStorage.connection 
     board = connection.getBoard(boardName)
@@ -18,6 +17,10 @@ def JiraVimBoardOpen(sessionStorage):
 
     # Buff Setup Commands
     buf, new = sessionStorage.getBuff(objName=boardName)
+    if isSplit:
+        vim.command("sbuffer "+str(buf.number))
+    else:
+        vim.command("buffer "+str(buf.number))
     if new:
         sessionStorage.assignBoard(board, buf)
         buf[0] = boardName + " BOARD"
@@ -45,8 +48,4 @@ def JiraVimBoardOpen(sessionStorage):
             
 
         vim.command("setl filetype=%s" % filetype)
-    else:
-        # Open the buffer in the current window
-        # TODO: Have a global variable control whether the issue is opened in the current window or a check will happen if it's already opened
-        vim.command("buf "+str(buf.number))
-         
+

--- a/python/common/board.py
+++ b/python/common/board.py
@@ -1,4 +1,3 @@
-import json
 
 class Board:
     def __init__(self, boardId, boardName, connection):
@@ -6,7 +5,7 @@ class Board:
         self.boardId = boardId
         self.boardName = boardName
         self.baseUrl = "/rest/agile/1.0/board/"+boardId
-        self.requiredProperties = ["key", "status", "summary"] 
+        self.requiredProperties = ["key", "status", "summary"]
 
     def getIssues(self, startAt=0, maxResults=50):
         r = self.connection.customRequest(self.baseUrl+"/issue?fields=%s&startAt=%d&maxResults=%d" % (','.join(self.requiredProperties), startAt, maxResults)).json()

--- a/python/common/connection.py
+++ b/python/common/connection.py
@@ -4,9 +4,7 @@ from .board import Board
 from .kanbanBoard import KanbanBoard
 from .issue import Issue
 import requests
-import json
 import re
-import vim
 
 class Connection:
     def __init__(self, name, email, token):
@@ -43,10 +41,10 @@ class Connection:
             else:
                 return KanbanBoard(boardId, boardName, self)
         else:
-            return None 
+            return None
 
     def getIssue(self, issueKey):
-        return Issue(issueKey)         
+        return Issue(issueKey, self)
 
     def customRequest(self, request):
         reqStr = self.__baseUrl + request

--- a/python/common/issue.py
+++ b/python/common/issue.py
@@ -1,5 +1,3 @@
-import json
-from jira import JIRA
 
 class Issue:
     def __init__(self, issueKey, connection):

--- a/python/common/kanbanBoard.py
+++ b/python/common/kanbanBoard.py
@@ -1,5 +1,4 @@
 from .board import Board
-import json
 
 class KanbanBoard(Board):
     def __init__(self, boardId, boardName, connection):
@@ -24,4 +23,3 @@ class KanbanBoard(Board):
             self.__columnIssues[self.__statusToColumn[statusId]].add(key)
 
         return [( a, list(b) ) for a,b in self.__columnIssues.items() if len(b) > 0]
-        

--- a/python/common/sessionObject.py
+++ b/python/common/sessionObject.py
@@ -25,7 +25,7 @@ class SessionObject():
         self.__bufferHash[issue.id] = buff
         self.__namesToIds[issue.issueKey] = issue.id
 
-    def getBufferById(self, key):
+    def getBufferByIndex(self, key):
         if key in self.__bufferHash:
             buff = self.__bufferHash[key]
             return buff if buff.valid else None
@@ -38,11 +38,11 @@ class SessionObject():
     # Returns the buffer, and a boolean that says whether the buffer is newly created or existing one
     def getBuff(self, objId=None, objName=None, isSplit=False):
         if objId is not None:
-            buff = self.getBufferById(objId)
+            buff = self.getBufferByIndex(objId)
             if buff is not None:
                 return ( buff, False )
         if objName is not None:
-            buff = self.getBufferById(objName)
+            buff = self.getBufferByIndex(objName)
             if buff is not None:
                 return ( buff, False )
         # return new buffer

--- a/python/common/sessionObject.py
+++ b/python/common/sessionObject.py
@@ -4,13 +4,14 @@ import vim
 
 class SessionObject():
     def __init__(self):
-        self.connection = self.getConnectionFromVars()
+        self.connection = SessionObject.getConnectionFromVars()
 
         # When retrieving buffers, we need to make sure that the buffer is valid. If the buffer is cleared or wiped, it will be marked invalid and we can't retriev it again.
         self.__bufferHash = {}
         self.__namesToIds = {}
 
-    def getConnectionFromVars(self):
+    @staticmethod
+    def getConnectionFromVars():
         domainName = vim.vars["jiraVimDomainName"].decode("utf-8")
         email = vim.vars["jiraVimEmail"].decode("utf-8")
         token = vim.vars["jiraVimToken"].decode("utf-8")
@@ -30,7 +31,7 @@ class SessionObject():
             buff = self.__bufferHash[key]
             return buff if buff.valid else None
         elif key in self.__namesToIds:
-            buff = self.__bufferHash[self.__namesToIds[key]] 
+            buff = self.__bufferHash[self.__namesToIds[key]]
             return buff if buff.valid else None
         else:
             return None
@@ -46,9 +47,9 @@ class SessionObject():
             if buff is not None:
                 return ( buff, False )
         # return new buffer
-        return (self.createBuffer(), True)
+        return (self.__createBuffer(), True)
 
-    def createBuffer(self):
+    def __createBuffer(self):
         # Creates a new buffer, saves it, and then uses the hidden command to hide it
         vim.command("new")
         buf = vim.current.buffer

--- a/python/common/sessionObject.py
+++ b/python/common/sessionObject.py
@@ -36,7 +36,7 @@ class SessionObject():
             return None
 
     # Returns the buffer, and a boolean that says whether the buffer is newly created or existing one
-    def getBuff(self, objId=None, objName=None) :
+    def getBuff(self, objId=None, objName=None, isSplit=False):
         if objId is not None:
             buff = self.getBufferById(objId)
             if buff is not None:
@@ -49,6 +49,9 @@ class SessionObject():
         return (self.createBuffer(), True)
 
     def createBuffer(self):
+        # Creates a new buffer, saves it, and then uses the hidden command to hide it
         vim.command("new")
-        return vim.current.buffer
+        buf = vim.current.buffer
+        vim.command("hide")
+        return buf
 

--- a/python/issues/open.py
+++ b/python/issues/open.py
@@ -1,6 +1,5 @@
 import vim
 import sys
-from ..common.connection import Connection
 from ..common.issue import Issue
 
 # Arguments are expected through sys.argv
@@ -30,11 +29,10 @@ def JiraVimIssueOpen(sessionStorage, isSplit=False):
         buf.append("="*len(issueKey))
         buf.append("")
 
-        buf.append("Summary: %s" % summary) 
+        buf.append("Summary: %s" % summary)
         buf.append("")
         
         buf.append("Description: %s" % description)
         buf.append("")
         
         vim.command("setl filetype=%s" % filetype)
-

--- a/python/issues/open.py
+++ b/python/issues/open.py
@@ -4,12 +4,16 @@ from ..common.connection import Connection
 from ..common.issue import Issue
 
 # Arguments are expected through sys.argv
-def JiraVimIssueOpen(sessionStorage):
+def JiraVimIssueOpen(sessionStorage, isSplit=False):
     issueKey = str(sys.argv[0])
     connection = sessionStorage.connection
     filetype = "jiraissueview"
 
     buf, new = sessionStorage.getBuff(objName=issueKey)
+    if isSplit:
+        vim.command("sbuffer "+str(buf.number))
+    else:
+        vim.command("buffer "+str(buf.number))
     if new:
         textWidth = vim.current.window.width
         issue = Issue(issueKey, connection)
@@ -33,6 +37,4 @@ def JiraVimIssueOpen(sessionStorage):
         buf.append("")
         
         vim.command("setl filetype=%s" % filetype)
-    else:
-        # Open the buffer in the current window
-        vim.command("buf "+str(buf.number))
+


### PR DESCRIPTION
## Changes
* Added split and nosplit commands for issues and boards, respectively.
* The `JiraVim...Open` commands no take an `isSplit` parameter that is default `False` for issues and `True` for boards.
* Reworked the `createBuffer` function of the `sessionObject` class. Now it opens a new window with a new buffer, saves the current buffer, hides it, and returns the buffer object.
* The `hidden` parameter is locally on in the issue and board filetypes. This keeps them in the buffer list when abandoned.
* Renamed a function in `sessionObject`

Most importantly, fixed #8.