### PR TITLE
Added Connection between Issues and Boards 

### DIFF
--- a/plugin/boardopen.vim
+++ b/plugin/boardopen.vim
@@ -1,13 +1,13 @@
 
 function! JiraVimBoardOpen(name)
-    echom "Loading board " . a:name
+    echo "Loading board " . a:name
     call check#CheckStorageSession()  
     execute "python3 sys.argv = [\"" . a:name . "\"]"
     execute "python3 python.boards.open.JiraVimBoardOpen(sessionStorage)"
 endfunction
 
 function! JiraVimBoardOpenNoSp(name)
-    echom "Loading board " . a:name
+    echo "Loading board " . a:name
     call check#CheckStorageSession()  
     execute "python3 sys.argv = [\"" . a:name . "\"]"
     execute "python3 python.boards.open.JiraVimBoardOpen(sessionStorage, False)"

--- a/plugin/returntoboard.vim
+++ b/plugin/returntoboard.vim
@@ -1,5 +1,5 @@
 
-function! JiraVimReturnToBoard(funcname)
+function! JiraVimBoardReturn(funcname)
     let s:boardName = substitute(matchstr(getline("1"), '\v^\s?\u+-'), '\v[\s-]+', '', 'g')
     if s:boardName != ""
         let s:Func = function(a:funcname, [s:boardName])

--- a/plugin/returntoboard.vim
+++ b/plugin/returntoboard.vim
@@ -5,5 +5,6 @@ function! JiraVimReturnToBoard(funcname)
         let s:Func = function(a:funcname, [s:boardName])
         call s:Func()
     else
+        throw "Could not find board name in the first row. Please sure the file is properly formatted" 
     endif
 endfunction

--- a/plugin/returntoboard.vim
+++ b/plugin/returntoboard.vim
@@ -1,0 +1,9 @@
+
+function! JiraVimReturnToBoard(funcname)
+    let s:boardName = substitute(matchstr(getline("1"), '\v^\s?\u+-'), '\v[\s-]+', '', 'g')
+    if s:boardName != ""
+        let s:Func = function(a:funcname, [s:boardName])
+        call s:Func()
+    else
+    endif
+endfunction

--- a/plugin/selectissue.vim
+++ b/plugin/selectissue.vim
@@ -1,0 +1,9 @@
+function! JiraVimBoardIssueSelect(funcname)
+    let s:line = getline(line("."))
+    let s:issueMatch = substitute(matchstr(s:line, '\v\u+-\d+\s'), '\s$', '', '')
+    if s:issueMatch != ""
+        let Func = function(a:funcname, [s:issueMatch])
+        call Func()
+    endif
+endfunction
+

--- a/syntax/jiraboardview.vim
+++ b/syntax/jiraboardview.vim
@@ -1,0 +1,3 @@
+
+setlocal cursorline
+highlight! link CursorLine Cursor

--- a/syntax/jirakanbanboardview.vim
+++ b/syntax/jirakanbanboardview.vim
@@ -1,0 +1,1 @@
+execute "source " . expand("<sfile>:h:p") . "/jiraboardview.vim"


### PR DESCRIPTION
## Changes
* Added four files: `plugin/returntoboard.vim/`, `plugin/selectissue.vim`, `syntax/jiraboardview.vim`, and `syntax/jirakanbanboardview.vim`. 
* The `returntoboard.vim` file provides a function `JiraVimReturnToBoard` that accepts a function name and opens the board using that function.
* The `selectissue.vim` file provides a function `JiraVimIssueSelect` that accepts a function name and opens the issue under the line of the cursor with that function.
* The `jiraboardview.vim` file provides a line highlight instead of a cursor highlight.
* The `jirakanbanboardview.vim` file sources the `jiraboardview.vim` file to copy the syntax instructions from there.

Fixes Issue #13