### PR TITLE
Improved Board to Issue path and the reverse

### DIFF
--- a/ftplugin/jiraissueview.vim
+++ b/ftplugin/jiraissueview.vim
@@ -4,3 +4,4 @@ setl hidden
 setl nomodifiable
 normal! gg
 
+

--- a/ftplugin/jiraissueview.vim
+++ b/ftplugin/jiraissueview.vim
@@ -3,5 +3,3 @@ setl buftype=nofile
 setl hidden
 setl nomodifiable
 normal! gg
-
-

--- a/plugin/returntoboard.vim
+++ b/plugin/returntoboard.vim
@@ -1,9 +1,8 @@
 
 function! JiraVimBoardReturn(funcname)
-    let s:boardName = substitute(matchstr(getline("1"), '\v^\s?\u+-'), '\v[\s-]+', '', 'g')
-    if s:boardName != ""
-        let s:Func = function(a:funcname, [s:boardName])
-        call s:Func()
+    if exists("b:jiraVimBoardName") && b:jiraVimBoardName !=# ""
+        let l:Func = function(a:funcname, [b:jiraVimBoardName])
+        call l:Func()
     else
         throw "Could not find board name in the first row. Please sure the file is properly formatted" 
     endif

--- a/plugin/returntoboard.vim
+++ b/plugin/returntoboard.vim
@@ -1,6 +1,6 @@
 
 function! JiraVimBoardReturn(funcname)
-    if exists("b:jiraVimBoardName") && b:jiraVimBoardName !=# ""
+    if exists("b:jiraVimBoardName") && b:jiraVimBoardName !=? ""
         let l:Func = function(a:funcname, [b:jiraVimBoardName])
         call l:Func()
     else

--- a/plugin/selectissue.vim
+++ b/plugin/selectissue.vim
@@ -1,12 +1,9 @@
 function! JiraVimBoardIssueSelect(funcname)
     let l:line = getline(line("."))
-    let l:boardName = b:jiraVimBoardName
     let l:issueMatch = substitute(matchstr(l:line, '\v\u+-\d+\s'), '\s$', '', '')
     if l:issueMatch != ""
         let l:Func = function(a:funcname, [l:issueMatch])
         call l:Func()
-        " Now in the issue buffer
-        let b:jiraVimBoardName = l:boardName
     endif
 endfunction
 

--- a/plugin/selectissue.vim
+++ b/plugin/selectissue.vim
@@ -1,9 +1,12 @@
 function! JiraVimBoardIssueSelect(funcname)
-    let s:line = getline(line("."))
-    let s:issueMatch = substitute(matchstr(s:line, '\v\u+-\d+\s'), '\s$', '', '')
-    if s:issueMatch != ""
-        let Func = function(a:funcname, [s:issueMatch])
-        call Func()
+    let l:line = getline(line("."))
+    let l:boardName = b:jiraVimBoardName
+    let l:issueMatch = substitute(matchstr(l:line, '\v\u+-\d+\s'), '\s$', '', '')
+    if l:issueMatch != ""
+        let l:Func = function(a:funcname, [l:issueMatch])
+        call l:Func()
+        " Now in the issue buffer
+        let b:jiraVimBoardName = l:boardName
     endif
 endfunction
 

--- a/python/boards/open.py
+++ b/python/boards/open.py
@@ -6,13 +6,6 @@ from ..common.kanbanBoard import KanbanBoard
 def JiraVimBoardOpen(sessionStorage, isSplit=True):
     boardName = str(sys.argv[0]) 
     connection = sessionStorage.connection
-    board = connection.getBoard(boardName)
-    issues = board.getIssues()
-
-    if isinstance(board, KanbanBoard):
-        filetype = "jirakanbanboardview"
-    else:
-        filetype = "jiraboardview"
 
     # Buff Setup Commands
     buf, new = sessionStorage.getBuff(objName=boardName)
@@ -20,9 +13,18 @@ def JiraVimBoardOpen(sessionStorage, isSplit=True):
         vim.command("sbuffer "+str(buf.number))
     else:
         vim.command("buffer "+str(buf.number))
+    vim.command("let b:jiraVimBoardName = \"%s\"" % boardName)
     if new:
+        board = connection.getBoard(boardName)
+        issues = board.getIssues()
+
+        if isinstance(board, KanbanBoard):
+            filetype = "jirakanbanboardview"
+        else:
+            filetype = "jiraboardview"
+
         sessionStorage.assignBoard(board, buf)
-        buf[0] = boardName + " BOARD"
+        buf[0] = boardName + " board"
         buf.append("="*(len(boardName)+7))
         buf.append("")
         textWidth = vim.current.window.width

--- a/python/common/connection.py
+++ b/python/common/connection.py
@@ -22,7 +22,7 @@ class Connection:
         reqStr = "/rest/agile/1.0/board"
         boardList = self.customRequest(reqStr).json()
         for v in boardList["values"]:
-            bName = re.match(r"\A(\w+)\sboard\Z", v["name"]).group(1)
+            bName = re.match(r"\A([\s\w]+)\sboard\Z", v["name"]).group(1)
             boardHash[bName] = v
         self.__boardHash = boardHash
 

--- a/python/common/sessionObject.py
+++ b/python/common/sessionObject.py
@@ -7,7 +7,7 @@ class SessionObject():
         self.connection = SessionObject.getConnectionFromVars()
 
         # When retrieving buffers, we need to make sure that the buffer is valid. 
-        #If the buffer is cleared or wiped, it will be marked invalid and we can't retriev it again.
+        #If the buffer is cleared or wiped, it will be marked invalid and we can't retrieve it again.
         self.__bufferHash = {}
         self.__namesToIds = {}
 
@@ -38,7 +38,7 @@ class SessionObject():
             return None
 
     # Returns the buffer, and a boolean that says whether the buffer is newly created or existing one
-    def getBuff(self, objId=None, objName=None, isSplit=False):
+    def getBuff(self, objId=None, objName=None, createNew=True, isSplit=False):
         if objId is not None:
             buff = self.getBufferByIndex(objId)
             if buff is not None:
@@ -48,7 +48,10 @@ class SessionObject():
             if buff is not None:
                 return (buff, False)
         # return new buffer
-        return (self.__createBuffer(), True)
+        if createNew:
+            return (self.__createBuffer(), True)
+        else:
+            return (None, False)
 
     def __createBuffer(self):
         # Creates a new buffer, saves it, and then uses the hidden command to hide it

--- a/python/issues/open.py
+++ b/python/issues/open.py
@@ -7,12 +7,18 @@ def JiraVimIssueOpen(sessionStorage, isSplit=False):
     issueKey = str(sys.argv[0])
     connection = sessionStorage.connection
     filetype = "jiraissueview"
+    # Carry on the board name from the previous buffer
+    if vim.eval("exists(\"b:jiraVimBoardName\")"):
+        boardName = vim.eval("b:jiraVimBoardName")
 
     buf, new = sessionStorage.getBuff(objName=issueKey)
     if isSplit:
         vim.command("sbuffer "+str(buf.number))
     else:
         vim.command("buffer "+str(buf.number))
+    if 'boardName' in locals():
+        vim.command("let b:jiraVimBoardName = \"%s\"" % boardName)
+
     if new:
         textWidth = vim.current.window.width
         issue = Issue(issueKey, connection)


### PR DESCRIPTION
## Motivation for changes
It's mostly explained in #16, but I will paraphrase here. The idea is that whenever a board is opened, it will assign it's name to the `b:jiraVimBoardName` variable for the buffer. Whenever an issue is opened, it will look at that variable and assign it's own buffer name to that. Then whenever the `JiraVimBoardReturn` function is called, it will read the value from the variable and open that board.

## Changes
* The `JiraVimBoardReturn` function now reads the buffer name not from the current buffer but from the `b:jiraVimBoardName` variable.
* the `JiraVimBoardIssueSelect` function and the `JiraVimBoardReturn` functions now use `l:` variables.
* The board and issues only get loaded once it's confirmed that the buffer is new in `python.boards.open.JiraVimBoardOpen`. The function also assigns the `b:jiraVimBoardName` variable for the board buffer.
* When finding boards, the `python.common.connection` variable now allows spaces in board names (as does Jira).
* The `getBuff` method of the `python.common.sessionObject.SessionObject` class now contains a `createNew` flag which controls whether a new buffer is created if the object or key is not found in the buffer list.
* The `python.issues.open.JiraVimIssueOpen` function now looks at the `b:jiraVimBoardName` parameter of the previous buffer and copies it to the buffer of the new issue.