### PR TITLE
Pagination support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ plugin/credentials.vim
 # Python byte-compiled, DLL files
 __pycache__/
 *.py[cod]
+
+# Vader test files
+test/

--- a/plugin/boardopen.vim
+++ b/plugin/boardopen.vim
@@ -2,13 +2,19 @@
 function! JiraVimBoardOpen(name)
     echo "Loading board " . a:name
     call check#CheckStorageSession()  
+
+    set modifiable
     execute "python3 sys.argv = [\"" . a:name . "\"]"
     execute "python3 python.boards.open.JiraVimBoardOpen(sessionStorage)"
+    set nomodifiable
 endfunction
 
 function! JiraVimBoardOpenNoSp(name)
     echo "Loading board " . a:name
     call check#CheckStorageSession()  
+
+    set modifiable
     execute "python3 sys.argv = [\"" . a:name . "\"]"
     execute "python3 python.boards.open.JiraVimBoardOpen(sessionStorage, False)"
+    set nomodifiable
 endfunction

--- a/plugin/issueopen.vim
+++ b/plugin/issueopen.vim
@@ -2,13 +2,19 @@
 function! JiraVimIssueOpen(name)
     echom "Loading issue " . a:name
     call check#CheckStorageSession()  
+
+    set modifiable
     execute "python3 sys.argv = [\"" . a:name . "\"]"
     execute "python3 python.issues.open.JiraVimIssueOpen(sessionStorage)"
+    set nomodifiable
 endfunction
 
 function! JiraVimIssueOpenSp(name)
     echom "Loading issue " . a:name
     call check#CheckStorageSession()  
+
+    set modifiable
     execute "python3 sys.argv = [\"" . a:name . "\"]"
     execute "python3 python.issues.open.JiraVimIssueOpen(sessionStorage, True)"
+    set nomodifiable
 endfunction

--- a/plugin/loadmore.vim
+++ b/plugin/loadmore.vim
@@ -6,7 +6,7 @@ function! JiraVimLoadMore()
 
     silent execute 'normal! ?\v^-+' . "\<cr>"
     normal! k
-    let l:categoryName = matchstr(getline("."), '\v^\u+')
+    let l:categoryName = matchstr(getline("."), '\v^(\u+\s?)+')
     let l:first_issue_line = line(".") + 2
 
     " Move the cursor back to the more line
@@ -14,6 +14,12 @@ function! JiraVimLoadMore()
     
     set modifiable
     execute "python3 sys.argv = [\"" . l:categoryName . "\", " . l:moreline . "]"
-    execute "python3 python.boards.more.JiraVimLoadMore(sessionStorage)"
+    if &filetype == "jirasprintview"
+        execute "python3 python.sprints.more.JiraVimLoadMore(sessionStorage)"
+    elseif &filetype == "jiraboardview" || &filetype == "jirakanbanboardview"
+        execute "python3 python.boards.more.JiraVimLoadMore(sessionStorage)"
+    else
+        throw "Not a valid target for loading more issues"
+    endif
     set nomodifiable
 endfunction

--- a/plugin/loadmore.vim
+++ b/plugin/loadmore.vim
@@ -1,0 +1,19 @@
+
+function! JiraVimLoadMore()
+    call check#CheckStorageSession()
+
+    let l:moreline = line(".")
+
+    silent execute 'normal! ?\v^-+' . "\<cr>"
+    normal! k
+    let l:categoryName = matchstr(getline("."), '\v^\u+')
+    let l:first_issue_line = line(".") + 2
+
+    " Move the cursor back to the more line
+    execute ":" . l:moreline
+    
+    set modifiable
+    execute "python3 sys.argv = [\"" . l:categoryName . "\", " . l:moreline . "]"
+    execute "python3 python.boards.more.JiraVimLoadMore(sessionStorage)"
+    set nomodifiable
+endfunction

--- a/plugin/setup.vim
+++ b/plugin/setup.vim
@@ -8,3 +8,4 @@ python3 import python.boards.open
 python3 import python.boards.more
 python3 import python.issues.open
 python3 import python.sprints.open
+python3 import python.sprints.more

--- a/plugin/setup.vim
+++ b/plugin/setup.vim
@@ -5,5 +5,6 @@ execute "python3 sys.path.append('" . s:python_dir . "../')"
 
 " Import all scripts with functions here
 python3 import python.boards.open
+python3 import python.boards.more
 python3 import python.issues.open
 python3 import python.sprints.open

--- a/plugin/sprintopen.vim
+++ b/plugin/sprintopen.vim
@@ -2,6 +2,9 @@
 function! JiraVimSprintOpen(name)
     echo "Loading sprint " . a:name
     call check#CheckStorageSession()
+
+    set modifiable
     execute "python3 sys.argv = [\"" . a:name . "\"]"
     execute "python3 python.sprints.open.JiraVimSprintOpen(sessionStorage, False)" 
+    set nomodifiable
 endfunction

--- a/python/boards/more.py
+++ b/python/boards/more.py
@@ -1,0 +1,25 @@
+import sys
+import vim
+
+from ..util.drawUtil import DrawUtil
+
+def JiraVimLoadMore(sessionStorage):
+    category_name = sys.argv[0]
+
+    more_line = int(sys.argv[1])
+    buf = vim.current.buffer
+    board_name = buf.vars["jiraVimBoardName"].decode("utf-8")
+
+    # Delete the MORE line and the space below: that will be handled by DrawUtil
+    del buf[more_line-1]
+    del buf[more_line-1]
+
+    board = sessionStorage.getBoard(board_name)
+
+    for c in board.columns:
+        if c.upper() == category_name:
+            category_name = c
+            break
+
+    line = more_line
+    DrawUtil.draw_items(buf, board, sessionStorage, line=line, itemExtractor=lambda o: o.getIssues(column=category_name), withCategoryHeaders=False)

--- a/python/boards/more.py
+++ b/python/boards/more.py
@@ -8,13 +8,12 @@ def JiraVimLoadMore(sessionStorage):
 
     more_line = int(sys.argv[1])
     buf = vim.current.buffer
-    board_name = buf.vars["jiraVimBoardName"].decode("utf-8")
 
     # Delete the MORE line and the space below: that will be handled by DrawUtil
     del buf[more_line-1]
     del buf[more_line-1]
 
-    board = sessionStorage.getBoard(board_name)
+    board = sessionStorage.getBoard(buf.number)
 
     for c in board.columns:
         if c.upper() == category_name:

--- a/python/boards/open.py
+++ b/python/boards/open.py
@@ -1,12 +1,10 @@
 import sys
 import vim
 from ..util.drawUtil import DrawUtil
-from ..common.kanbanBoard import KanbanBoard
 
 # arguments expected in sys.argv
 def JiraVimBoardOpen(sessionStorage, isSplit=True):
     boardName = str(sys.argv[0])
-    connection = sessionStorage.connection
 
     # Buff Setup Commands
     buf, new = sessionStorage.getBuff(objName=boardName)

--- a/python/boards/open.py
+++ b/python/boards/open.py
@@ -1,6 +1,6 @@
 import sys
 import vim
-from ..util.drawObject import drawObject
+from ..util.drawUtil import DrawUtil
 
 # arguments expected in sys.argv
 def JiraVimBoardOpen(sessionStorage, isSplit=True):
@@ -16,4 +16,6 @@ def JiraVimBoardOpen(sessionStorage, isSplit=True):
     vim.command("let b:jiraVimBoardName = \"%s\"" % boardName)
     if new:
         board = connection.getBoard(boardName)
-        drawObject(buf, board, boardName, sessionStorage)
+        DrawUtil.draw_header(buf, board, boardName)
+        DrawUtil.draw_items(buf, board, sessionStorage)
+        DrawUtil.set_filetype(board)

--- a/python/boards/open.py
+++ b/python/boards/open.py
@@ -1,6 +1,7 @@
 import sys
 import vim
 from ..util.drawUtil import DrawUtil
+from ..common.kanbanBoard import KanbanBoard
 
 # arguments expected in sys.argv
 def JiraVimBoardOpen(sessionStorage, isSplit=True):
@@ -16,6 +17,11 @@ def JiraVimBoardOpen(sessionStorage, isSplit=True):
     vim.command("let b:jiraVimBoardName = \"%s\"" % boardName)
     if new:
         board = connection.getBoard(boardName)
-        DrawUtil.draw_header(buf, board, boardName)
-        DrawUtil.draw_items(buf, board, sessionStorage)
+        line = DrawUtil.draw_header(buf, board, boardName)
+        if isinstance(board, KanbanBoard):
+            # Need to account for columns
+            for col in board.columns:
+                line = DrawUtil.draw_items(buf, board, sessionStorage, itemExtractor=lambda b, col_name=col: b.getIssues(column=col_name))
+        else:
+            DrawUtil.draw_items(buf, board, sessionStorage)
         DrawUtil.set_filetype(board)

--- a/python/boards/open.py
+++ b/python/boards/open.py
@@ -12,9 +12,8 @@ def JiraVimBoardOpen(sessionStorage, isSplit=True):
         vim.command("sbuffer "+str(buf.number))
     else:
         vim.command("buffer "+str(buf.number))
-    vim.command("let b:jiraVimBoardName = \"%s\"" % boardName)
     if new:
-        board = sessionStorage.getBoard(boardName)
+        board = sessionStorage.getBoard(buf.number, boardName=boardName)
         DrawUtil.draw_header(buf, board, boardName)
         DrawUtil.draw_items(buf, board, sessionStorage)
         DrawUtil.set_filetype(board)

--- a/python/boards/open.py
+++ b/python/boards/open.py
@@ -16,7 +16,7 @@ def JiraVimBoardOpen(sessionStorage, isSplit=True):
         vim.command("buffer "+str(buf.number))
     vim.command("let b:jiraVimBoardName = \"%s\"" % boardName)
     if new:
-        board = connection.getBoard(boardName)
+        board = sessionStorage.getBoard(boardName)
         line = DrawUtil.draw_header(buf, board, boardName)
         if isinstance(board, KanbanBoard):
             # Need to account for columns

--- a/python/boards/open.py
+++ b/python/boards/open.py
@@ -17,11 +17,6 @@ def JiraVimBoardOpen(sessionStorage, isSplit=True):
     vim.command("let b:jiraVimBoardName = \"%s\"" % boardName)
     if new:
         board = sessionStorage.getBoard(boardName)
-        line = DrawUtil.draw_header(buf, board, boardName)
-        if isinstance(board, KanbanBoard):
-            # Need to account for columns
-            for col in board.columns:
-                line = DrawUtil.draw_items(buf, board, sessionStorage, itemExtractor=lambda b, col_name=col: b.getIssues(column=col_name))
-        else:
-            DrawUtil.draw_items(buf, board, sessionStorage)
+        DrawUtil.draw_header(buf, board, boardName)
+        DrawUtil.draw_items(buf, board, sessionStorage)
         DrawUtil.set_filetype(board)

--- a/python/common/board.py
+++ b/python/common/board.py
@@ -27,4 +27,4 @@ class Board:
     def getIssues(self, column=None):
         r = self.issueExtractor.__next__()
         categoryName = "All Issues"
-        return [(categoryName, [(i["key"], "") for i in r["issues"]])]
+        return [(categoryName, self.issueExtractor.finished, [(i["key"], "") for i in r["issues"]])]

--- a/python/common/board.py
+++ b/python/common/board.py
@@ -1,4 +1,6 @@
 
+from ..util.itemExtractor import ItemExtractor
+
 class Board:
     def __init__(self, boardId, boardName, connection):
         self.connection = connection
@@ -17,7 +19,8 @@ class Board:
             for s in col["statuses"]:
                 self.statusToColumn[s["id"]] = cName
 
-    def getIssues(self, startAt=0, maxResults=50):
-        r = self.connection.customRequest(self.baseUrl+"/issue?fields=%s&startAt=%d&maxResults=%d" % (','.join(self.requiredProperties), \
-                startAt, maxResults)).json()
+        self.issueExtractor = ItemExtractor(self.connection, self.baseUrl+"/issue?fields=%s", lambda: (','.join(self.requiredProperties),))
+
+    def getIssues(self, column=None):
+        r = self.issueExtractor.__next__()
         return [("All Issues", [(i["key"], "") for i in r["issues"]])]

--- a/python/common/board.py
+++ b/python/common/board.py
@@ -11,11 +11,14 @@ class Board:
 
         self.boardConf = self.connection.customRequest(self.baseUrl+"/configuration").json()
         self.statusToColumn = {}
+        self.columns = set()
+
         """
         The idea here is that each column can display many statuses. So the relationship from status to column is many to one. Then each instance sorts issues into columns on its own.
         """
         for col in self.boardConf["columnConfig"]["columns"]:
             cName = col["name"]
+            self.columns.add(cName)
             for s in col["statuses"]:
                 self.statusToColumn[s["id"]] = cName
 
@@ -23,4 +26,5 @@ class Board:
 
     def getIssues(self, column=None):
         r = self.issueExtractor.__next__()
-        return [("All Issues", [(i["key"], "") for i in r["issues"]])]
+        categoryName = "All Issues"
+        return [(categoryName, [(i["key"], "") for i in r["issues"]])]

--- a/python/common/connection.py
+++ b/python/common/connection.py
@@ -1,11 +1,12 @@
 
+import re
+import requests
+
 from jira import JIRA
 from .board import Board
 from .kanbanBoard import KanbanBoard
 from .scrumBoard import ScrumBoard
 from .issue import Issue
-import requests
-import re
 
 class Connection:
     def __init__(self, name, email, token):

--- a/python/common/kanbanBoard.py
+++ b/python/common/kanbanBoard.py
@@ -5,10 +5,18 @@ from ..util.itemExtractor import ItemExtractor
 class KanbanBoard(Board):
     def __init__(self, boardId, boardName, connection):
         Board.__init__(self, boardId, boardName, connection)
-        self.__columnToIssues = {}
+        self.columnExtractors = {}
+
         self.issueExtractor = ItemExtractor(self.connection, self.baseUrl+"/issue?fields=%s", lambda: (','.join(self.requiredProperties),))
 
+        for col in self.columns:
+            self.columnExtractors[col] = ItemExtractor.create_column_issue_extractor(self, col)
+
+
     def getIssues(self, column=None):
-        r = self.issueExtractor.__next__()
+        if column and column in self.columnExtractors:
+            r = self.columnExtractors[column].__next__()
+        else:
+            r = self.issueExtractor.__next__()
         # Sort issues by Category
-        return ItemCategorizer.issueCategorizer(r["issues"], self.statusToColumn, self.__columnToIssues)
+        return ItemCategorizer.issueCategorizer(r["issues"], self.statusToColumn)

--- a/python/common/kanbanBoard.py
+++ b/python/common/kanbanBoard.py
@@ -1,13 +1,14 @@
 from .board import Board
 from ..util.itemCategorizer import ItemCategorizer
+from ..util.itemExtractor import ItemExtractor
 
 class KanbanBoard(Board):
     def __init__(self, boardId, boardName, connection):
         Board.__init__(self, boardId, boardName, connection)
         self.__columnToIssues = {}
+        self.issueExtractor = ItemExtractor(self.connection, self.baseUrl+"/issue?fields=%s", lambda: (','.join(self.requiredProperties),))
 
-    def getIssues(self, startAt=0, maxResults=50):
-        r = self.connection.customRequest(self.baseUrl+"/issue?fields=%s&startAt=%d&maxResults=%d" % (','.join(self.requiredProperties), \
-               startAt, maxResults)).json()
+    def getIssues(self, column=None):
+        r = self.issueExtractor.__next__()
         # Sort issues by Category
         return ItemCategorizer.issueCategorizer(r["issues"], self.statusToColumn, self.__columnToIssues)

--- a/python/common/kanbanBoard.py
+++ b/python/common/kanbanBoard.py
@@ -19,4 +19,4 @@ class KanbanBoard(Board):
         else:
             r = self.issueExtractor.__next__()
         # Sort issues by Category
-        return ItemCategorizer.issueCategorizer(r["issues"], self.statusToColumn)
+        return ItemCategorizer.issueCategorizer(r["issues"], self.statusToColumn), bool(column and not self.columnExtractors[column].finished)

--- a/python/common/kanbanBoard.py
+++ b/python/common/kanbanBoard.py
@@ -14,7 +14,7 @@ class KanbanBoard(Board):
         """
         Get a batch of issues from board.
 
-        Get a batch of issues from the board, either sorted by column or from all columns. If by column returns at most 10 from the column specified. Otherwise, collects issues from all columns in batches and returns them, categorized.
+        Get a batch of issues from the board, either sorted by column. Returns at most 10 from the column specified. Otherwise, collects issues from all columns in batches and returns them, categorized.
 
         Parameters
         ----------
@@ -24,19 +24,17 @@ class KanbanBoard(Board):
         Returns
         -------
         List
-            Categorized list of (<column_name>, [issue keys]) tuples according to the issue categorizer from ItemCategorizer.
+            Categorized list of (<column_name>, <more left>, [issue keys]) tuples according to the issue categorizer from ItemCategorizer.
 
         """
 
         if column:
             columns = [column]
-            returnLambda = lambda a, b: (a, b)
         else:
             columns = self.columns
-            returnLambda = lambda a, b: a
         returnIssues = []
         for c in columns:
             r = self.columnExtractors[c].__next__()
-            returnIssues += ItemCategorizer.issueCategorizer(r["issues"], self.statusToColumn)
+            returnIssues += ItemCategorizer.issueCategorizer(r["issues"], self.statusToColumn, self.columnExtractors)
         # Sort issues by Category
-        return returnLambda(returnIssues, bool(column and not self.columnExtractors[column].finished))
+        return returnIssues

--- a/python/common/scrumBoard.py
+++ b/python/common/scrumBoard.py
@@ -22,7 +22,7 @@ class ScrumBoard(Board):
             self.__sprintsById[int(sprintObj["id"])] = sprint
             self.__sprintsByName[sprintObj["name"]] = sprint
 
-    def getSprints(self, startAt=0, maxResults=50):
+    def getSprints(self):
         # No pagination support for Sprints yet
         return [["Sprints", False, [(name, " ") for name in self.__sprintsByName]]]
 

--- a/python/common/scrumBoard.py
+++ b/python/common/scrumBoard.py
@@ -23,7 +23,8 @@ class ScrumBoard(Board):
             self.__sprintsByName[sprintObj["name"]] = sprint
 
     def getSprints(self, startAt=0, maxResults=50):
-        return [["Sprints", [(name, " ") for name in self.__sprintsByName]]]
+        # No pagination support for Sprints yet
+        return [["Sprints", False, [(name, " ") for name in self.__sprintsByName]]]
 
     def getSprint(self, key):
         if key in self.__sprintsById:

--- a/python/common/sessionObject.py
+++ b/python/common/sessionObject.py
@@ -29,7 +29,7 @@ class SessionObject():
 
         Parameters
         ----------
-        board : Board or Sprint
+        board : Board
             Object to be associated with the buffer
         buff : Vim Buffer
             A vim buffer object to be associated with board
@@ -43,14 +43,12 @@ class SessionObject():
         self.__bufferHash[board.id] = buff
         self.__namesToIds[board.boardName] = board.id
         self.__boardsHash[buff.number] = board
-        self.__boardsHash[board.boardName] = board
 
     def assignSprint(self, sprint, buff):
         """
         Assigns a sprint to the session sprint cache. Note that it doesn't assign by sprint name.
         """
         self.__sprintsHash[buff.number] = sprint
-        self.__sprintsHash[buff] = sprint
 
     def assignIssue(self, issue, buff):
         self.__bufferHash[issue.id] = buff
@@ -66,18 +64,20 @@ class SessionObject():
         else:
             return None
 
-    def getBoard(self, boardIdentifier):
+    def getBoard(self, boardIdentifier, boardName=None):
         """
         Retrieve board object based on buffer number
 
-        This function takes in an identifier and tries to retrieve an object from the cache corresponding to the identifier (which can be a buffer id, a buffer, or a string of the board name). If it does not find a string object, it goes ahead and creates one by calling the getBoard method of the connection object. If it does not find a buffer number of buffer object in the cache, it creates one based on the jiraVimBoardName variable. 
+        This function takes in an identifier and tries to retrieve an object from the cache corresponding to the identifier (which can be a buffer id, a buffer, or a string of the board name). If it does not find a string object, it goes ahead and creates one by calling the getBoard method of the connection object. If it does not find a buffer number of buffer object in the cache, it creates one based on the jiraVimBoardName variable.
 
         This function only accounts for missing keys in the cache.
 
         Parameters
         ----------
-        buf : Integer or Buffer or String
+        buf : Integer or Buffer
             Buffer object or integer representing the number of the buffer
+        boardName : String
+            Name of board to be created if board doesn't exist in cache
 
         Returns
         -------
@@ -88,21 +88,20 @@ class SessionObject():
         create_new_object = self.connection.getBoard
 
         if isinstance(boardIdentifier, int):
-            board = self.__boardsHash.get(boardIdentifier, create_new_object(vim.buffers[boardIdentifier].vars["jiraVimBoardName"]))
-            self.assignBoard(board, vim.buffer[boardIdentifier])
-            return board
-        if isinstance(boardIdentifier, str):
-            board = self.__boardsHash.get(boardIdentifier, create_new_object(boardIdentifier))
+            board = self.__boardsHash.get(boardIdentifier, create_new_object(boardName))
+            self.assignBoard(board, vim.buffers[boardIdentifier])
             return board
         if boardIdentifier in vim.buffers:
-            board = self.__boardsHash.get(boardIdentifier.number, create_new_object(boardIdentifier.vars["jiraVimBoardName"]))
+            board = self.__boardsHash.get(boardIdentifier.number, create_new_object(boardName))
             self.assignBoard(board, boardIdentifier)
             return board
         return None
 
     def getSprint(self, sprintIdentifier):
         """
-        Similar to getBoard for boards: returns cached sprint if it could find it for this buffer or name
+        Similar to getBoard for boards: returns cached sprint if it could find it for this buffer or name.
+
+        Note: doesn't work if you input
         """
         if sprintIdentifier in vim.buffers:
             sprint = self.__sprintsHash.get(sprintIdentifier.number, None)

--- a/python/common/sessionObject.py
+++ b/python/common/sessionObject.py
@@ -47,10 +47,10 @@ class SessionObject():
 
     def assignSprint(self, sprint, buff):
         """
-        Assigns a sprint to the session sprint cache
+        Assigns a sprint to the session sprint cache. Note that it doesn't assign by sprint name.
         """
         self.__sprintsHash[buff.number] = sprint
-        self.__sprintsHash[sprint.name] = sprint
+        self.__sprintsHash[buff] = sprint
 
     def assignIssue(self, issue, buff):
         self.__bufferHash[issue.id] = buff
@@ -111,7 +111,7 @@ class SessionObject():
             return sprint
         sprint = self.__sprintsHash.get(sprintIdentifier, None)
         if sprint and isinstance(sprintIdentifier, int):
-            self.assignSprint(sprint, sprintIdentifier)
+            self.assignSprint(sprint, vim.buffers[sprintIdentifier])
         return sprint
 
     # Returns the buffer, and a boolean that says whether the buffer is newly created or existing one

--- a/python/common/sprint.py
+++ b/python/common/sprint.py
@@ -9,12 +9,13 @@ class Sprint():
         self.__state = state
         self.__startDate = startDate
         self.__endDate = endDate
-        self.baseUrl = "/rest/agile/1.0/board/"+str(board.id)+"/sprint/"+str(id)
+        self.baseUrl = "/rest/agile/1.0/board/"+str(board.id)+"/sprint/"+str(sprintId)
         self.connection = connection
         self.requiredProperties = ["key", "status", "summary"]
         self.__columnToIssues = {}
 
     def getIssues(self, startAt=0, maxResults=50):
-        r = self.connection.customRequest(self.baseUrl+"/issue?fields=%s&startAt=%d&maxResults=%d" % (','.join(self.requiredProperties), startAt, maxResults)).json()
+        request_text = self.baseUrl+"/issue?fields=%s&startAt=%d&maxResults=%d" % (','.join(self.requiredProperties), startAt, maxResults)
+        r = self.connection.customRequest(request_text).json()
 
         return ItemCategorizer.issueCategorizer(r["issues"], self.board.statusToColumn, self.__columnToIssues)

--- a/python/common/sprint.py
+++ b/python/common/sprint.py
@@ -13,11 +13,10 @@ class Sprint():
         self.baseUrl = "/rest/agile/1.0/board/"+str(board.id)+"/sprint/"+str(sprintId)
         self.connection = connection
         self.requiredProperties = ["key", "status", "summary"]
-        self.__columnToIssues = {}
 
         self.issueExtractor = ItemExtractor(self.connection, self.baseUrl+"/issue?fields=%s", lambda: (','.join(self.requiredProperties),))
 
     def getIssues(self, column=None):
         r = self.issueExtractor.__next__()
 
-        return ItemCategorizer.issueCategorizer(r["issues"], self.board.statusToColumn, self.__columnToIssues)
+        return ItemCategorizer.issueCategorizer(r["issues"], self.board.statusToColumn)

--- a/python/common/sprint.py
+++ b/python/common/sprint.py
@@ -14,15 +14,12 @@ class Sprint():
         self.connection = connection
         self.requiredProperties = ["key", "status", "summary"]
 
-        #self.issueExtractor = ItemExtractor(self.connection, self.baseUrl+"/issue?fields=%s", lambda: (','.join(self.requiredProperties),))
         self.columnExtractors = {}
         for col in self.board.columns:
             self.columnExtractors[col] = ItemExtractor.create_column_issue_extractor(self.board, col)
 
 
     def getIssues(self, column=None):
-        #r = self.issueExtractor.__next__()
-
         if column:
             columns = [column]
         else:
@@ -31,5 +28,4 @@ class Sprint():
         for c in columns:
             r = self.columnExtractors[c].__next__()
             returnIssues += ItemCategorizer.issueCategorizer(r["issues"], self.board.statusToColumn, self.columnExtractors)
-        #return ItemCategorizer.issueCategorizer(r["issues"], self.board.statusToColumn)
         return returnIssues

--- a/python/common/sprint.py
+++ b/python/common/sprint.py
@@ -14,9 +14,22 @@ class Sprint():
         self.connection = connection
         self.requiredProperties = ["key", "status", "summary"]
 
-        self.issueExtractor = ItemExtractor(self.connection, self.baseUrl+"/issue?fields=%s", lambda: (','.join(self.requiredProperties),))
+        #self.issueExtractor = ItemExtractor(self.connection, self.baseUrl+"/issue?fields=%s", lambda: (','.join(self.requiredProperties),))
+        self.columnExtractors = {}
+        for col in self.board.columns:
+            self.columnExtractors[col] = ItemExtractor.create_column_issue_extractor(self.board, col)
+
 
     def getIssues(self, column=None):
-        r = self.issueExtractor.__next__()
+        #r = self.issueExtractor.__next__()
 
-        return ItemCategorizer.issueCategorizer(r["issues"], self.board.statusToColumn)
+        if column:
+            columns = [column]
+        else:
+            columns = self.board.columns
+        returnIssues = []
+        for c in columns:
+            r = self.columnExtractors[c].__next__()
+            returnIssues += ItemCategorizer.issueCategorizer(r["issues"], self.board.statusToColumn, self.columnExtractors)
+        #return ItemCategorizer.issueCategorizer(r["issues"], self.board.statusToColumn)
+        return returnIssues

--- a/python/common/sprint.py
+++ b/python/common/sprint.py
@@ -1,4 +1,5 @@
 from ..util.itemCategorizer import ItemCategorizer
+from ..util.itemExtractor import ItemExtractor
 
 class Sprint():
     def __init__(self, sprintId, url, board, connection, state=None, name=None, startDate=None, endDate=None):
@@ -14,8 +15,9 @@ class Sprint():
         self.requiredProperties = ["key", "status", "summary"]
         self.__columnToIssues = {}
 
-    def getIssues(self, startAt=0, maxResults=50):
-        request_text = self.baseUrl+"/issue?fields=%s&startAt=%d&maxResults=%d" % (','.join(self.requiredProperties), startAt, maxResults)
-        r = self.connection.customRequest(request_text).json()
+        self.issueExtractor = ItemExtractor(self.connection, self.baseUrl+"/issue?fields=%s", lambda: (','.join(self.requiredProperties),))
+
+    def getIssues(self, column=None):
+        r = self.issueExtractor.__next__()
 
         return ItemCategorizer.issueCategorizer(r["issues"], self.board.statusToColumn, self.__columnToIssues)

--- a/python/sprints/more.py
+++ b/python/sprints/more.py
@@ -8,13 +8,12 @@ def JiraVimLoadMore(sessionStorage):
 
     more_line = int(sys.argv[1])
     buf = vim.current.buffer
-    sprint_name = buf.vars["jiraVimSprintName"].decode("utf-8")
 
     # Delete the MORE line and the space below: that will be handled by DrawUtil
     del buf[more_line-1]
     del buf[more_line-1]
 
-    sprint = sessionStorage.getSprint(sprint_name)
+    sprint = sessionStorage.getSprint(buf.number)
 
     for c in sprint.board.columns:
         if c.upper() == category_name:

--- a/python/sprints/more.py
+++ b/python/sprints/more.py
@@ -1,0 +1,25 @@
+import sys
+import vim
+
+from ..util.drawUtil import DrawUtil
+
+def JiraVimLoadMore(sessionStorage):
+    category_name = sys.argv[0]
+
+    more_line = int(sys.argv[1])
+    buf = vim.current.buffer
+    sprint_name = buf.vars["jiraVimSprintName"].decode("utf-8")
+
+    # Delete the MORE line and the space below: that will be handled by DrawUtil
+    del buf[more_line-1]
+    del buf[more_line-1]
+
+    sprint = sessionStorage.getSprint(sprint_name)
+
+    for c in sprint.board.columns:
+        if c.upper() == category_name:
+            category_name = c
+            break
+
+    line = more_line
+    DrawUtil.draw_items(buf, sprint, sessionStorage, line=line, itemExtractor=lambda o: o.getIssues(column=category_name), withCategoryHeaders=False)

--- a/python/sprints/open.py
+++ b/python/sprints/open.py
@@ -1,6 +1,6 @@
 import sys
 import vim
-from ..util.drawObject import drawObject
+from ..util.drawUtil import DrawUtil
 
 def JiraVimSprintOpen(sessionStorage, isSplit=True):
     sprintName = str(sys.argv[0])
@@ -17,4 +17,8 @@ def JiraVimSprintOpen(sessionStorage, isSplit=True):
         else:
             vim.command("buffer "+str(buf.number))
         vim.command("let b:jiraVimBoardName = \"%s\"" % boardName)
-        drawObject(buf, board.getSprint(sprintName), sprintName, sessionStorage)
+
+        sprint = board.getSprint(sprintName)
+        DrawUtil.draw_header(buf, sprint, sprintName)
+        DrawUtil.draw_items(buf, sprint, sessionStorage)
+        DrawUtil.set_filetype(sprint)

--- a/python/sprints/open.py
+++ b/python/sprints/open.py
@@ -6,22 +6,18 @@ def JiraVimSprintOpen(sessionStorage, isSplit=True):
     sprintName = str(sys.argv[0])
 
     boardBuffer = vim.current.buffer
-    boardName = boardBuffer.vars["jiraVimBoardName"].decode("utf-8")
 
-    if boardName is not None:
-        board = sessionStorage.getBoard(boardName)
-        buf, _ = sessionStorage.getBuff(objName=sprintName)
-        if isSplit:
-            vim.command("sbuffer "+str(buf.number))
-        else:
-            vim.command("buffer "+str(buf.number))
-        vim.command("let b:jiraVimBoardName = \"%s\"" % boardName)
-        vim.command("let b:jiraVimSprintName = \"%s\"" % sprintName)
+    board = sessionStorage.getBoard(boardBuffer.number)
+    buf, _ = sessionStorage.getBuff(objName=sprintName)
+    if isSplit:
+        vim.command("sbuffer "+str(buf.number))
+    else:
+        vim.command("buffer "+str(buf.number))
 
-        sprint = sessionStorage.getSprint(sprintName)
-        if not sprint:
-            sprint = board.getSprint(sprintName)
-            sessionStorage.assignSprint(sprint, buf)
-        DrawUtil.draw_header(buf, sprint, sprintName)
-        DrawUtil.draw_items(buf, sprint, sessionStorage)
-        DrawUtil.set_filetype(sprint)
+    sprint = sessionStorage.getSprint(sprintName)
+    if not sprint:
+        sprint = board.getSprint(sprintName)
+        sessionStorage.assignSprint(sprint, buf)
+    DrawUtil.draw_header(buf, sprint, sprintName)
+    DrawUtil.draw_items(buf, sprint, sessionStorage)
+    DrawUtil.set_filetype(sprint)

--- a/python/sprints/open.py
+++ b/python/sprints/open.py
@@ -16,8 +16,12 @@ def JiraVimSprintOpen(sessionStorage, isSplit=True):
         else:
             vim.command("buffer "+str(buf.number))
         vim.command("let b:jiraVimBoardName = \"%s\"" % boardName)
+        vim.command("let b:jiraVimSprintName = \"%s\"" % sprintName)
 
-        sprint = board.getSprint(sprintName)
+        sprint = sessionStorage.getSprint(sprintName)
+        if not sprint:
+            sprint = board.getSprint(sprintName)
+            sessionStorage.assignSprint(sprint, buf)
         DrawUtil.draw_header(buf, sprint, sprintName)
         DrawUtil.draw_items(buf, sprint, sessionStorage)
         DrawUtil.set_filetype(sprint)

--- a/python/sprints/open.py
+++ b/python/sprints/open.py
@@ -4,13 +4,12 @@ from ..util.drawUtil import DrawUtil
 
 def JiraVimSprintOpen(sessionStorage, isSplit=True):
     sprintName = str(sys.argv[0])
-    connection = sessionStorage.connection
 
     boardBuffer = vim.current.buffer
     boardName = boardBuffer.vars["jiraVimBoardName"].decode("utf-8")
 
     if boardName is not None:
-        board = connection.getBoard(boardName)
+        board = sessionStorage.getBoard(boardName)
         buf, _ = sessionStorage.getBuff(objName=sprintName)
         if isSplit:
             vim.command("sbuffer "+str(buf.number))

--- a/python/util/drawUtil.py
+++ b/python/util/drawUtil.py
@@ -84,81 +84,81 @@ class DrawUtil():
             )
 
         buf[0] = name + (" %s" % postfix)
-            buf.append("="*(len(name)+7))
-            buf.append("")
+        buf.append("="*(len(name)+7))
+        buf.append("")
 
-        @staticmethod
-        def draw_item(buf, item, line=None):
-            """
-            Draws an item in the buffer.
+    @staticmethod
+    def draw_item(buf, item, line=None):
+        """
+        Draws an item in the buffer.
 
-            Draws an item on the specified line or at the end of the buffer if no line is specified. Does not apply formatting: formatting is applied when drawing a category.
+        Draws an item on the specified line or at the end of the buffer if no line is specified. Does not apply formatting: formatting is applied when drawing a category.
 
-            Parameters
-            ----------
-            buf : vim.buffer
-                Buffer to be drawn onto
-            item : tuple
-                Tuple that contains the key and summary of the item
-            line : int (Optional)
-                Line on which to draw the item. If not specified, appends to the end of the buffer
+        Parameters
+        ----------
+        buf : vim.buffer
+            Buffer to be drawn onto
+        item : tuple
+            Tuple that contains the key and summary of the item
+        line : int (Optional)
+            Line on which to draw the item. If not specified, appends to the end of the buffer
 
-            Returns
-            -------
-            tuple
-                the length of the key and the length of the summary as a tuple
+        Returns
+        -------
+        tuple
+            the length of the key and the length of the summary as a tuple
 
-            """
+        """
 
-            key, summ = item
-            buf.append(key + " " + summ, len(buf)-1 if not line else line-1)
-            return len(key), len(summ)
+        key, summ = item
+        buf.append(key + " " + summ, len(buf)-1 if not line else line-1)
+        return len(key), len(summ)
 
-        @staticmethod
-        def draw_category(buf, obj, category, line=None, formatter=None):
-            """
-            Draws a category in the buffer.
+    @staticmethod
+    def draw_category(buf, obj, category, line=None, formatter=None):
+        """
+        Draws a category in the buffer.
 
-            Gets a category and draws it in the buffer at the specified line. Also applies formatting afterwards.
+        Gets a category and draws it in the buffer at the specified line. Also applies formatting afterwards.
 
-            Parameters
-            ----------
-            buf : vim.buffer
-                Buffer to be drawn onto
-            obj : Object
-                Object to be examined
-            category : tuple
-                Tuple that contains the name of the category and a list of issues
-            line : int (Optional)
-                Line to be drawn onto (0-indexed). If none exist, defaults to appending to the file.
-            formatter : Lambda (Optional)
-                Lambda that accepts 5 arguments (
-                    startLine,
-                    endLine,
-                    maxKeyLen,
-                    maxSummLen,
-                    window_width
-                    )
-                The values of the variables should be self-explanatory. If not defined, it's chosen depending on the type of object, dud function for scrum boards and DrawUtil.ISSUE_FORMATTER otherwise.
-
-            Returns
-            -------
-            int
-                the line number of the blank line under the last item in the category
-
-            """
-
-            window_width = vim.current.window.width
-
-            # No formatting for the scrum board
-            formatter = formatter if formatter else DrawUtil.__type_selector(
-                obj=obj,
-                scrum=lambda a, b, c, d, e: a,
-                default=DrawUtil.ISSUE_FORMATTER
+        Parameters
+        ----------
+        buf : vim.buffer
+            Buffer to be drawn onto
+        obj : Object
+            Object to be examined
+        category : tuple
+            Tuple that contains the name of the category and a list of issues
+        line : int (Optional)
+            Line to be drawn onto (0-indexed). If none exist, defaults to appending to the file.
+        formatter : Lambda (Optional)
+            Lambda that accepts 5 arguments (
+                startLine,
+                endLine,
+                maxKeyLen,
+                maxSummLen,
+                window_width
                 )
+            The values of the variables should be self-explanatory. If not defined, it's chosen depending on the type of object, dud function for scrum boards and DrawUtil.ISSUE_FORMATTER otherwise.
 
-            if not line:
-                line = len(buf)+1
+        Returns
+        -------
+        int
+            the line number of the blank line under the last item in the category
+
+        """
+
+        window_width = vim.current.window.width
+
+        # No formatting for the scrum board
+        formatter = formatter if formatter else DrawUtil.__type_selector(
+            obj=obj,
+            scrum=lambda a, b, c, d, e: a,
+            default=DrawUtil.ISSUE_FORMATTER
+            )
+
+        if not line:
+            line = len(buf)+1
 
         buf.append(category[0].upper()+":", line-1)
         line += 1

--- a/python/util/drawUtil.py
+++ b/python/util/drawUtil.py
@@ -251,7 +251,7 @@ class DrawUtil():
         return line
 
     @staticmethod
-    def draw_more(buf, line):
+    def draw_more(buf, line=None):
         """
         Draws the "MORE" symbol for columns representing extracts that have not been fully consumed.
 
@@ -259,8 +259,8 @@ class DrawUtil():
         ----------
         buf : Buffer
             Buffer to be drawn to
-        line : Integer
-            Line to be drawn on
+        line : Integer (Optional)
+            Line to be drawn on. Defaults to the end of the buffer.
 
         Returns
         -------
@@ -268,6 +268,9 @@ class DrawUtil():
             returns line + 1
 
         """
+
+        if not line:
+            line = len(buf) + 1
 
         buf.append("---MORE---", line-1)
 

--- a/python/util/drawUtil.py
+++ b/python/util/drawUtil.py
@@ -117,7 +117,7 @@ class DrawUtil():
         return len(key), len(summ)
 
     @staticmethod
-    def draw_category(buf, obj, category, line=None, formatter=None):
+    def draw_category(buf, obj, category, line=None, more=False, formatter=None):
         """
         Draws a category in the buffer.
 
@@ -133,6 +133,8 @@ class DrawUtil():
             Tuple that contains the name of the category and a list of issues
         line : int (Optional)
             Line to be drawn onto (0-indexed). If none exist, defaults to appending to the file.
+        more : Boolean (Optional)
+            Boolean that determines whether a MORE is displayed at the bottom of the items. Defaults to False.
         formatter : Lambda (Optional)
             Lambda that accepts 5 arguments (
                 startLine,
@@ -178,6 +180,9 @@ class DrawUtil():
             maxSummLen = max([lenSumm, maxSummLen])
         endLine = line-1
 
+        if more:
+            line = DrawUtil.draw_more(buf, line)
+
         # append an empty line at the end
         buf.append("", line-1)
 
@@ -202,7 +207,7 @@ class DrawUtil():
         line : int (Optional)
             Line on which to start drawing. If not defined, appends to the end of the buffer
         itemExtractor : Lambda (Optional)
-            Lambda that accepts an object and returns a list of items separated by category. If not defined, defaults to calling the getIssues method of the object.
+            Lambda that accepts an object and returns a list of items separated by category. If not defined, defaults to calling the getIssues method of the object. Can also return a tuple where the first element is the list of items, and the second is a boolean that represents whether there are more elements.
 
         Returns
         -------
@@ -230,11 +235,39 @@ class DrawUtil():
             obj=obj
             )(obj, buf)
 
-        items = itemExtractor(obj)
+        extraction = itemExtractor(obj)
+
+        if type(extraction) is tuple:
+            items, more = extraction
+        else:
+            items = extraction
+            more = False
 
         for cat in items:
-            line = DrawUtil.draw_category(buf, obj, cat, line) + 1
+            line = DrawUtil.draw_category(buf, obj, cat, line, more=more) + 1
         return line
+
+    @staticmethod
+    def draw_more(buf, line):
+        """
+        Draws the "MORE" symbol for columns representing extracts that have not been fully consumed.
+
+        Parameters
+        ----------
+        buf : Buffer
+            Buffer to be drawn to
+        line : Integer
+            Line to be drawn on
+
+        Returns
+        -------
+        Integer
+            returns line + 1
+
+        """
+
+        buf.append("---MORE---", line-1)
+        return line+1
 
     @staticmethod
     def set_filetype(obj, filetype=None):

--- a/python/util/drawUtil.py
+++ b/python/util/drawUtil.py
@@ -1,0 +1,265 @@
+from collections import OrderedDict
+import vim
+
+from ..common.kanbanBoard import KanbanBoard
+from ..common.scrumBoard import ScrumBoard
+from ..common.board import Board
+from ..common.sprint import Sprint
+from ..common.issue import Issue
+
+
+class DrawUtil():
+
+    MAPPINGS = OrderedDict({
+        "kanban": KanbanBoard,
+        "scrum": ScrumBoard,
+        "board": Board,
+        "sprint": Sprint,
+        "issue": Issue
+        })
+    RESERVED_KEYWORDS = ["default", "obj"]
+    ISSUE_FORMATTER = lambda startLine, endLine, maxKeyLen, maxSumLen, textWidth: vim.command("%d,%dTabularize /\\u\+-\d\+\s/r0l%dr0" % (startLine, endLine, textWidth-maxKeyLen-maxSumLen-7))
+
+    @staticmethod
+    def __type_selector(**args):
+        """
+        This is a helper method to return a value based on the type of an object.
+
+        Many cases here will depend on the type of the object that is being drawn onto a buffer. This means that we need to somehow create mappings to assign crucial parameters depending on the type of the object in question. This method uses an OrderedDict to check the type of the object from bottom to top (so if class A inherits from class B, class A will be checked before class B) and return an appropriate value.
+
+        Parameters
+        ----------
+        **args: dict
+            A dictionary object that may contain the following fields:
+                kanban,
+                scrum,
+                board,
+                sprint,
+                issue,
+                default,
+                obj
+
+            The obj mapping is required for the operation to work.
+
+        Returns
+        -------
+        Some value
+            This is the value obtained from the key in the **args dict that corresponds to the most granular class of the object passed in. If the object matches none of the types from **args, use value at key "default". If no default, returns None.
+
+        """
+
+        # Check to see that obj exists and throw an error if it doesn't
+        obj = args["obj"]
+
+        for k, c in DrawUtil.MAPPINGS.items():
+            if k not in DrawUtil.RESERVED_KEYWORDS and k in args and isinstance(obj, c):
+                return args[k]
+
+        return args.get("default", None)
+
+    @staticmethod
+    def draw_header(buf, obj, name):
+        """
+        Draw the header for object.
+
+        Parameters
+        ----------
+        buf : vim.buffer
+            Buffer to be drawn onto
+        obj : Object
+            The object to examine
+        name : String
+            The name of the object to be written.
+
+        Returns
+        -------
+        Nothing
+
+        """
+
+        postfix = DrawUtil.__type_selector(
+            board="board",
+            sprint="sprint",
+            obj=obj
+            )
+
+        buf[0] = name + (" %s" % postfix)
+            buf.append("="*(len(name)+7))
+            buf.append("")
+
+        @staticmethod
+        def draw_item(buf, item, line=None):
+            """
+            Draws an item in the buffer.
+
+            Draws an item on the specified line or at the end of the buffer if no line is specified. Does not apply formatting: formatting is applied when drawing a category.
+
+            Parameters
+            ----------
+            buf : vim.buffer
+                Buffer to be drawn onto
+            item : tuple
+                Tuple that contains the key and summary of the item
+            line : int (Optional)
+                Line on which to draw the item. If not specified, appends to the end of the buffer
+
+            Returns
+            -------
+            tuple
+                the length of the key and the length of the summary as a tuple
+
+            """
+
+            key, summ = item
+            buf.append(key + " " + summ, len(buf)-1 if not line else line-1)
+            return len(key), len(summ)
+
+        @staticmethod
+        def draw_category(buf, obj, category, line=None, formatter=None):
+            """
+            Draws a category in the buffer.
+
+            Gets a category and draws it in the buffer at the specified line. Also applies formatting afterwards.
+
+            Parameters
+            ----------
+            buf : vim.buffer
+                Buffer to be drawn onto
+            obj : Object
+                Object to be examined
+            category : tuple
+                Tuple that contains the name of the category and a list of issues
+            line : int (Optional)
+                Line to be drawn onto (0-indexed). If none exist, defaults to appending to the file.
+            formatter : Lambda (Optional)
+                Lambda that accepts 5 arguments (
+                    startLine,
+                    endLine,
+                    maxKeyLen,
+                    maxSummLen,
+                    window_width
+                    )
+                The values of the variables should be self-explanatory. If not defined, it's chosen depending on the type of object, dud function for scrum boards and DrawUtil.ISSUE_FORMATTER otherwise.
+
+            Returns
+            -------
+            int
+                the line number of the blank line under the last item in the category
+
+            """
+
+            window_width = vim.current.window.width
+
+            # No formatting for the scrum board
+            formatter = formatter if formatter else DrawUtil.__type_selector(
+                obj=obj,
+                scrum=lambda a, b, c, d, e: a,
+                default=DrawUtil.ISSUE_FORMATTER
+                )
+
+            if not line:
+                line = len(buf)+1
+
+        buf.append(category[0].upper()+":", line-1)
+        line += 1
+        buf.append("-"*(len(category[0])+1), line-1)
+        line += 1
+
+        startLine = line
+        items = category[1]
+        # Using maxSummLen to clarify that we are measuring the maximum length of the summary
+        maxKeyLen, maxSummLen = 0, 0
+        for item in items:
+            lenKey, lenSumm = DrawUtil.draw_item(buf, item, line=line)
+            line += 1
+            maxKeyLen = max([lenKey, maxKeyLen])
+            maxSummLen = max([lenSumm, maxSummLen])
+        endLine = line-1
+
+        # append an empty line at the end
+        buf.append("", line-1)
+
+        formatter(startLine, endLine, maxKeyLen, maxSummLen, window_width)
+        return line
+
+    @staticmethod
+    def draw_items(buf, obj, sessionStorage, line=None, itemExtractor=None):
+        """
+        Draw a set of items from an object.
+
+        This method draws items extracted via itemExtractor from object, and draws them to the buffer.
+
+        Parameters
+        ----------
+        buf : vim.buffer
+            Buffer to be drawn onto
+        obj : Object
+            Object from which items will be extracted
+        sessionStorage : SessionStorage
+            The sessionStorage object associated with current session.
+        line : int (Optional)
+            Line on which to start drawing. If not defined, appends to the end of the buffer
+        itemExtractor : Lambda (Optional)
+            Lambda that accepts an object and returns a list of items separated by category. If not defined, defaults to calling the getIssues method of the object.
+
+        Returns
+        -------
+        Nothing
+
+        """
+
+        if not line:
+            line = len(buf)+1
+
+        if not itemExtractor:
+            itemExtractor = DrawUtil.__type_selector(
+                obj=obj,
+                default=lambda o: o.getIssues(),
+                scrum=lambda o: o.getSprints()
+                )
+
+        # Associate buffer with object in sessionStorage
+        addBoardFunc = sessionStorage.assignBoard
+        dudFunc = lambda a, b: b
+        DrawUtil.__type_selector(
+            board=addBoardFunc,
+            default=dudFunc,
+            obj=obj
+            )(obj, buf)
+
+        items = itemExtractor(obj)
+
+        for cat in items:
+            line = DrawUtil.draw_category(buf, obj, cat, line) + 1
+
+    @staticmethod
+    def set_filetype(obj, filetype=None):
+        """
+        Sets filetype in current buffer
+
+        Sets filetype in current buffer depending on the type of object. Recommended to execute this function after you\'ve written any changes since this function with set modifiable to off
+
+        Parameters
+        ----------
+        obj : Object
+            Object to be examined
+        filetype : String (Optional)
+            Sets the current buffer to specified filetype unless it's none, then selection is done based on type of object
+
+        Returns
+        -------
+        Nothing
+
+        """
+        if not filetype:
+            filetype = DrawUtil.__type_selector(
+                kanban="jirakanbanboardview",
+                scrum="jirascrumboardview",
+                sprint="jirasprintview",
+                board="jiraboardview",
+                default="",
+                obj=obj
+                )
+
+        vim.command("setl filetype=%s" % filetype)
+

--- a/python/util/drawUtil.py
+++ b/python/util/drawUtil.py
@@ -117,7 +117,7 @@ class DrawUtil():
         return len(key), len(summ)
 
     @staticmethod
-    def draw_category(buf, obj, category, line=None, more=False, formatter=None):
+    def draw_category(buf, obj, category, line=None, more=False, formatter=None, with_header=True):
         """
         Draws a category in the buffer.
 
@@ -144,6 +144,8 @@ class DrawUtil():
                 window_width
                 )
             The values of the variables should be self-explanatory. If not defined, it's chosen depending on the type of object, dud function for scrum boards and DrawUtil.ISSUE_FORMATTER otherwise.
+        with_header : Boolean (Optional)
+            Boolean that specifies if the header of the category should be displayed. True by default.
 
         Returns
         -------
@@ -164,10 +166,11 @@ class DrawUtil():
         if not line:
             line = len(buf)+1
 
-        buf.append(category[0].upper()+":", line-1)
-        line += 1
-        buf.append("-"*(len(category[0])+1), line-1)
-        line += 1
+        if with_header:
+            buf.append(category[0].upper()+":", line-1)
+            line += 1
+            buf.append("-"*(len(category[0])+1), line-1)
+            line += 1
 
         startLine = line
         items = category[1]
@@ -190,7 +193,7 @@ class DrawUtil():
         return line
 
     @staticmethod
-    def draw_items(buf, obj, sessionStorage, line=None, itemExtractor=None):
+    def draw_items(buf, obj, sessionStorage, line=None, itemExtractor=None, withCategoryHeaders=True):
         """
         Draw a set of items from an object.
 
@@ -208,6 +211,8 @@ class DrawUtil():
             Line on which to start drawing. If not defined, appends to the end of the buffer
         itemExtractor : Lambda (Optional)
             Lambda that accepts an object and returns a list of items separated by category. If not defined, defaults to calling the getIssues method of the object. Can also return a tuple where the first element is the list of items, and the second is a boolean that represents whether there are more elements.
+        withCategoryHeaders : Boolean (Optional)
+            Boolean that determines whether the headers for the categories will be displayed. True by default.
 
         Returns
         -------
@@ -244,7 +249,7 @@ class DrawUtil():
             more = False
 
         for cat in items:
-            line = DrawUtil.draw_category(buf, obj, cat, line, more=more) + 1
+            line = DrawUtil.draw_category(buf, obj, cat, line, more=more, with_header=withCategoryHeaders) + 1
         return line
 
     @staticmethod
@@ -267,6 +272,7 @@ class DrawUtil():
         """
 
         buf.append("---MORE---", line-1)
+
         return line+1
 
     @staticmethod

--- a/python/util/drawUtil.py
+++ b/python/util/drawUtil.py
@@ -73,7 +73,8 @@ class DrawUtil():
 
         Returns
         -------
-        Nothing
+        int
+            This represents the line number of the blank line under the header. Intended to be a constant since it's expected that this is written at the top of the file.
 
         """
 
@@ -86,6 +87,7 @@ class DrawUtil():
         buf[0] = name + (" %s" % postfix)
         buf.append("="*(len(name)+7))
         buf.append("")
+        return 3
 
     @staticmethod
     def draw_item(buf, item, line=None):
@@ -204,7 +206,8 @@ class DrawUtil():
 
         Returns
         -------
-        Nothing
+        int
+            the line number of the blank line under the last item in the category
 
         """
 
@@ -231,6 +234,7 @@ class DrawUtil():
 
         for cat in items:
             line = DrawUtil.draw_category(buf, obj, cat, line) + 1
+        return line
 
     @staticmethod
     def set_filetype(obj, filetype=None):

--- a/python/util/drawUtil.py
+++ b/python/util/drawUtil.py
@@ -210,7 +210,7 @@ class DrawUtil():
         line : int (Optional)
             Line on which to start drawing. If not defined, appends to the end of the buffer
         itemExtractor : Lambda (Optional)
-            Lambda that accepts an object and returns a list of items separated by category. If not defined, defaults to calling the getIssues method of the object. Can also return a tuple where the first element is the list of items, and the second is a boolean that represents whether there are more elements.
+            Lambda that accepts an object and returns a list of items separated by category. If not defined, defaults to calling the getIssues method of the object. Returns a list of tuples with 3 elements each: the name of the category, the "more" parameter, and the list of item keys.
         withCategoryHeaders : Boolean (Optional)
             Boolean that determines whether the headers for the categories will be displayed. True by default.
 
@@ -233,23 +233,21 @@ class DrawUtil():
 
         # Associate buffer with object in sessionStorage
         addBoardFunc = sessionStorage.assignBoard
+        addSprintFunc = sessionStorage.assignSprint
         dudFunc = lambda a, b: b
         DrawUtil.__type_selector(
             board=addBoardFunc,
+            sprint=addSprintFunc,
             default=dudFunc,
             obj=obj
             )(obj, buf)
 
         extraction = itemExtractor(obj)
 
-        if type(extraction) is tuple:
-            items, more = extraction
-        else:
-            items = extraction
-            more = False
-
-        for cat in items:
-            line = DrawUtil.draw_category(buf, obj, cat, line, more=more, with_header=withCategoryHeaders) + 1
+        for cat in extraction:
+            more = cat[1]
+            item_list = (cat[0], cat[2])
+            line = DrawUtil.draw_category(buf, obj, item_list, line, more=more, with_header=withCategoryHeaders) + 1
         return line
 
     @staticmethod

--- a/python/util/itemCategorizer.py
+++ b/python/util/itemCategorizer.py
@@ -2,7 +2,7 @@
 class ItemCategorizer():
 
     @staticmethod
-    def issueCategorizer(issues, statusToColumn):
+    def issueCategorizer(issues, statusToColumn, columnExtractors):
         """
         Categorizes issues based on category.
 
@@ -14,6 +14,8 @@ class ItemCategorizer():
             A json string containing an "issues" field that contains an array of issues to be processed.
         statusToColumn : Dict
             A dictionary that maps status to columns. This is a many to one relationship.
+        columnExtractos : Dict
+            A dictionary that maps columns to the extractor. Used only to assign the "more" parameter, that is to see if the extractor is finished.
 
         Returns
         -------
@@ -30,4 +32,4 @@ class ItemCategorizer():
             if column not in columnToIssues:
                 columnToIssues[column] = set()
             columnToIssues[column].add(key)
-        return [(a, list(b)) for a, b in columnToIssues.items() if len(b) > 0]
+        return [(a, not columnExtractors[a].finished, list(b)) for a, b in columnToIssues.items() if len(b) > 0]

--- a/python/util/itemCategorizer.py
+++ b/python/util/itemCategorizer.py
@@ -2,7 +2,7 @@
 class ItemCategorizer():
 
     @staticmethod
-    def issueCategorizer(issues, statusToColumn, columnToIssues):
+    def issueCategorizer(issues, statusToColumn):
         """
         Categorizes issues based on category.
 
@@ -14,8 +14,6 @@ class ItemCategorizer():
             A json string containing an "issues" field that contains an array of issues to be processed.
         statusToColumn : Dict
             A dictionary that maps status to columns. This is a many to one relationship.
-        columnToIssues : Dict
-            A dictionary that maps column strings to sets of issue keys. This dictionary is written to by the method.
 
         Returns
         -------
@@ -24,6 +22,7 @@ class ItemCategorizer():
 
         """
 
+        columnToIssues = {}
         for i in issues:
             key = (i["key"], i["fields"]["summary"])
             statusId = i["fields"]["status"]["id"]

--- a/python/util/itemCategorizer.py
+++ b/python/util/itemCategorizer.py
@@ -3,6 +3,27 @@ class ItemCategorizer():
 
     @staticmethod
     def issueCategorizer(issues, statusToColumn, columnToIssues):
+        """
+        Categorizes issues based on category.
+
+        Categorizes issues based on the status to column mappings. NOTE: THIS DOES NOT CREATE ISSUE OBJECTS
+
+        Parameters
+        ----------
+        issues : String
+            A json string containing an "issues" field that contains an array of issues to be processed.
+        statusToColumn : Dict
+            A dictionary that maps status to columns. This is a many to one relationship.
+        columnToIssues : Dict
+            A dictionary that maps column strings to sets of issue keys. This dictionary is written to by the method.
+
+        Returns
+        -------
+        List
+            a list that contains tuples of (column, <list of issue keys>) for each column in the columnToIssues dict.
+
+        """
+
         for i in issues:
             key = (i["key"], i["fields"]["summary"])
             statusId = i["fields"]["status"]["id"]

--- a/python/util/itemExtractor.py
+++ b/python/util/itemExtractor.py
@@ -1,0 +1,59 @@
+
+class ItemExtractor:
+    """
+    This class is designed to be an iterator that iterates over some items presented by Jira.
+    """
+
+    def __init__(self, connection, connection_string, provider, batch_size=10):
+        """
+        Initializes an iterator for retrieving a Jira resource with pagination.
+
+        This initializes an iterator that provides resources in batches based on the resource defined by the connection string and values provided in the provider function.
+
+        Parameters
+        ----------
+        connection : Connection
+            Connection object to be used to retrieve the resources from Jira.
+        connection_string : String
+            This is the string that is passed as a custom Request to retrieve resources. Values that depend on the object must be formatted in and passed in with the provider function.
+        provider : Lambda
+            This is a lambda that takes in no arguments and returns a tuple (with any number of values) that contain the arguments to be formatted into the connection_string.
+        batch_size : Integer (Optional)
+            This is an optional argument that sets the batch size for retrieval.
+
+        Returns
+        -------
+        Nothing
+
+        """
+
+        self.start_at_marker = 0
+        self.connection_string = connection_string
+        self.connection = connection
+        self.provider = provider
+        self.batch_size = batch_size
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        """
+        Returns the next batch of resources from Jira.
+
+        Takes the start position, and returns the next <batch_size> resources from Jira through the connection. If no more exist, will continue to increment self.start_at_marker, so it's not safe to call continuously until new resources appear in Jira.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        String
+            JSON String returned by the connection
+
+        """
+
+        request_string = (self.connection_string + "&startAt=%d&maxResults=%d") % (self.provider() + (self.start_at_marker, self.batch_size))
+        resources_response = self.connection.customRequest(request_string).json()
+        self.start_at_marker = resources_response["startAt"]
+        return resources_response

--- a/python/util/itemExtractor.py
+++ b/python/util/itemExtractor.py
@@ -55,5 +55,33 @@ class ItemExtractor:
 
         request_string = (self.connection_string + "&startAt=%d&maxResults=%d") % (self.provider() + (self.start_at_marker, self.batch_size))
         resources_response = self.connection.customRequest(request_string).json()
+        #print(resources_response)
         self.start_at_marker = resources_response["startAt"]
         return resources_response
+
+    @staticmethod
+    def create_column_issue_extractor(board, column, batch_size=10):
+        """
+        Create an ItemExtractor that extracts only items from one column.
+
+        Create an ItemExtractor that creates an extractor only for statuses associated with a specific column of a board.
+
+        Parameters
+        ----------
+        board : Board
+            The board object from which we are extracting the issues
+        column : String
+            The column name of the column to be extracted
+        batch_size : Integer (Optional)
+            Optional batch size
+
+        Returns
+        -------
+        ItemExtractor
+            ItemExtractor instance that gets issues from this particular column
+
+        """
+
+        #print([k for k, v in board.statusToColumn.items() if v == column])
+        return ItemExtractor(board.connection, board.baseUrl+"/issue?fields=%s&jql=status IN (%s)", lambda: (','.join(board.requiredProperties), ','.join(['\'%s\'' % k for k, v in board.statusToColumn.items() if v == column])), batch_size)
+


### PR DESCRIPTION
Addresses issue #21, adds pagination, plus a bunch of other maintenance stuff that was necessary to ensure this.

## Changes:
* Added the `plugin/loadmore.vim` file that is responsible for initiating the process of loading more issues. Introduces the `JiraVimLoadMore` function that should be called on `MORE` lines. It checks for the category by searching backwards for the category header, and then obtaining a column by matching with board columns. It then resets the cursor to the original position and calls an appropriate function to load more issues based on whether the object in question is a board or a sprint.
* The files `boardopen.vim`, `issueopen.vim`, `sprintopen.vim`, and `loadmore.vim` now turn on `modifiable` before calling the python code, and turn it back off after the python code finished executing.
* Modified the setup to load more scripts from the python boards and sprints directories.
* Added `python/boards/more.py` file that is called from the `JiraVimLoadMore`. Deletes the old MORE lines and punts the drawing process to `DrawUtil`.
* Modified `python/boards/open.py` to use `DrawUtil` methods to display the issues in buffer.
* Modified `python/common/board.py` file and added a field, `self.columns` to the Board object that reflects the set of columns for the board. Rewrote the `getIssues` method to use the `IssueExtractor` mechanism to present issues with only one category ("All Issues").
* Modified `python/common/kanbanboard.py`. Replaced the mapping from column to issues with per-column `IssueExtractor` objects. Each object represents a column from which issues will be extracted. The `getIssues` method now also accepts a column, and can retrieve issues by columns. In general, the `getIssues` method retrieves either at most 10 from all issues, or at most 10 from a single column. It then categorizes the issues with the `ItemCategorizer` class which **introducted a new format for issue transfer** (see below).
* Modified `python/common/scrumBoard.py` to play nice with the new format. **Pagination is not supported from Scrum Boards yet**.
* The `getIssues` and `getSprints` methods have been relieved of pagination duty. That now lies in `ItemExtractor` objects.
* Modified the `SessionObject` class in `python/common/sessionObject.py` file. Added a boards and sprints cache that caches board and sprint objects. It caches them by buffer id **and not by names**. That way we can associate objects with buffers, which is the best way it would work with pagination and independent views philosophy (more about this below).
* Modified the `Sprint` object from `python/common/sprint.py` file. Made the column retrieval more similar to how it happened in `KanbanBoard` for pagination purposes.  
* Added the `python/sprints/open.py` file. It's almost a crystal copy of `python/boards/open.py`, with the exception that all items are retrieved through the sprint object. 
* Modified the `python/sprints/open.py` file to utilize `DrawUtil`. 
* Modified the `python/util/itemCategorizer.py` class. The `issueCategorizer` now accepts columnExtractors to check if columns have been fully exhausted, and returns a new format for packing issue keys, namely lists of objects in the format of `(<name of category>, <True if column is fully exhausted>, <list of issue keys>)`. The exhausted field is also referenced in the document as the "more field".
* Removed the `jiraVimBoardName` and `jiraVimSprintName` parameters from use and being set.

## New Classes

### DrawUtil

This is a new class that handles all displaying of items on the buffers for Boards and Sprints (and soon Issues). It contains a collection of static methods to be used to display elements in the buffer. All methods except for `draw_header` and `set_filetype` accept a line optional argument that specifies the line on which to draw the desired object. If not specified, draws at the end of the buffer. Keep in mind that this line object is **the vim line that you desire to draw on**, so it's 1-indexed and it's the line you want to draw on *not draw below* (like most vim methods). All methods except `set_filetype` return the vim line below the last one that the method drew on.

A very useful internal method is the `__type_selector` method. It accepts a dictionary that maps types to values. All of the mappings are defined in the `MAPPINGS` variable of the class (except for some reserved mappings). The `RESERVED_KEYWORDS` variable contains reserved keywords, the `default` and `obj` keyword. The `obj` keyword defines the object to be examined. It is then compared to types defined in `MAPPINGS`, and if it matches one, the corresponding key is used to extract a value from the input dictionary and return it. So if `obj` is an instance of `KanbanBoard` the method will return `args[kanban]`. If none of the types match, returns the value specified by `default`.

The mechanic above is used throughout the class, and that's why many methods require the `obj`, often simply for type comparisons. This is also probably one of the most documented classes in this project.

### ItemExtractor

This is a new item that is designed to handle pagination and retrieval of paginated items from Jira. It implements the iterable interface, however most of the calls in the project use the `__next` method to obtain new records.

Note that parameters like batch size are provided at initialization. Once initialized, the batch size can't be altered. You can reset the counter, however, so that the batch starts retreiving issues from the beginning again.

There is a static convenience method called `create_column_issue_extractor` to help create extractors of issue columns quickly.

## The Independent Buffer 

This is an idea that I'm trying to implement in this project. Each buffer is independent from every other buffer. That is, if I open the board in one buffer, and then open the buffer in another, they will be talking to two completely different `Board` objects. 

This way, we give the user more flexibility with his displays, and in this update it was particularly relevant since we didn't want two buffers contacting the same column item extractors. That would result in some issues displayed on one buffer, and a different set on the other buffer.
