### PR TITLE
Added ordering to board displays

### DIFF
--- a/python/common/board.py
+++ b/python/common/board.py
@@ -11,14 +11,17 @@ class Board:
 
         self.boardConf = self.connection.customRequest(self.baseUrl+"/configuration").json()
         self.statusToColumn = {}
-        self.columns = set()
+        self.columns = list()
 
         """
         The idea here is that each column can display many statuses. So the relationship from status to column is many to one. Then each instance sorts issues into columns on its own.
         """
+        col_set = set()
         for col in self.boardConf["columnConfig"]["columns"]:
             cName = col["name"]
-            self.columns.add(cName)
+            if cName not in col_set:
+                self.columns.append(cName)
+                col_set.add(cName)
             for s in col["statuses"]:
                 self.statusToColumn[s["id"]] = cName
 

--- a/python/util/itemCategorizer.py
+++ b/python/util/itemCategorizer.py
@@ -30,6 +30,6 @@ class ItemCategorizer():
             statusId = i["fields"]["status"]["id"]
             column = statusToColumn[statusId]
             if column not in columnToIssues:
-                columnToIssues[column] = set()
-            columnToIssues[column].add(key)
-        return [(a, not columnExtractors[a].finished, list(b)) for a, b in columnToIssues.items() if len(b) > 0]
+                columnToIssues[column] = list()
+            columnToIssues[column].append(key)
+        return [(a, not columnExtractors[a].finished, b) for a, b in columnToIssues.items() if len(b) > 0]

--- a/test/boardcolumnordering.vader
+++ b/test/boardcolumnordering.vader
@@ -1,0 +1,23 @@
+
+Execute (Open the test board):
+  JiraVimBoardOpen TEST
+
+Then (Test Order):
+  Assert getline(1) ==# "TEST board", "No header found" 
+  Assert getline(2) ==# "===========", "No underlining found"
+
+  /BACKLOG
+  let b:backlogLine = line(".")
+
+  /SELECTED\ FOR\ DEVELOPMENT
+  let b:developmentLine = line(".")
+
+  /IN\ PROGRESS
+  let b:progressLine = line(".")
+
+  /DONE
+  let b:doneLine = line(".")
+
+  Assert b:backlogLine < b:developmentLine, "Bad ordering"
+  Assert b:developmentLine < b:progressLine, "Bad ordering" 
+  Assert b:progressLine < b:doneLine, "Bad ordering" 

--- a/test/boardissueordering.vader
+++ b/test/boardissueordering.vader
@@ -1,0 +1,17 @@
+
+Execute (Open the test board):
+  JiraVimBoardOpen TEST
+
+Then (Test Order):
+  Assert getline(1) ==# "TEST board", "No header found" 
+  Assert getline(2) ==# "===========", "No underlining found"
+
+  /BACKLOG
+  normal! 3j
+
+  while getline(".") !~? '\v---MORE---'
+    let b:thisIssue = substitute(matchstr(getline("."), '\v^\u+-\d+'), '\v^\u+-', "", '')
+    let b:prevIssue = substitute(matchstr(getline(line(".")-1), '\v^\u+-\d+'), '\v^\u+-', "", '')    
+    Assert str2nr(b:prevIssue) < str2nr(b:thisIssue), "Bad ordering or Issues"
+    normal! j
+  endwhile

--- a/test/run_all_tests.sh
+++ b/test/run_all_tests.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-vim '+Vader!*' && echo Success || echo Failure


### PR DESCRIPTION
Resolves #17 

## Changes:
* Converts `board.columns` from a set to a list to preserve column ordering
* Converts `columnToIssues` items in `ItemCategorizer` to list from set, preserving issue ordering like in Jira.
* Added tests to assert the orderings are preserved
