### PR TITLE
Support board names with spaces and without statuses

### DIFF
--- a/python/common/board.py
+++ b/python/common/board.py
@@ -1,4 +1,6 @@
 
+import urllib
+
 from ..util.itemExtractor import ObjectItemExtractor
 
 class Board:
@@ -6,7 +8,7 @@ class Board:
         self.connection = connection
         self.id = boardId
         self.boardName = boardName
-        self.baseUrl = "/rest/agile/1.0/board/"+boardId
+        self.baseUrl = "/rest/agile/1.0/board/"+urllib.parse.quote(boardId)
         self.requiredProperties = ["key", "status", "summary"]
 
         self.boardConf = self.connection.customRequest(self.baseUrl+"/configuration").json()

--- a/python/util/itemExtractor.py
+++ b/python/util/itemExtractor.py
@@ -66,10 +66,15 @@ class ObjectItemExtractor:
         ObjectItemExtractor
         """
         def provider(startAt, maxResults=batch_size):
-            connection_string = board.baseUrl+"/issue?fields=%s&jql=status IN (%s)"
+            connection_string = board.baseUrl+"/issue?fields=%s"
             req_fields_list = ','.join(board.requiredProperties)
             req_status_list = ','.join(['\'%s\'' % k for k, v in board.statusToColumn.items() if v == column])
-            req_vars = (req_fields_list, req_status_list) + (startAt, maxResults)
+            req_vars = (req_fields_list,) + (startAt, maxResults)
+            if req_status_list:
+                connection_string += "&jql=status IN (%s)"
+                req_vars = list(req_vars)
+                req_vars.insert(1, req_status_list)
+                req_vars = tuple(req_vars)
             request_string = (connection_string + "&startAt=%d&maxResults=%d") % (req_vars)
 
             response = board.connection.customRequest(request_string).json()

--- a/test/openspaceboard.vader
+++ b/test/openspaceboard.vader
@@ -1,4 +1,4 @@
-" This test is to test for a board that doens't happen to have a "board" suffix.
+" This test is to test opening of a board that has a space in the middle, in this case Space Jam
 
 Execute (Open the special board):
   JiraVimBoardOpen Space Jam

--- a/test/openspaceboard.vader
+++ b/test/openspaceboard.vader
@@ -1,0 +1,19 @@
+" This test is to test for a board that doens't happen to have a "board" suffix.
+
+Execute (Open the special board):
+  JiraVimBoardOpen Space Jam
+  sleep 2
+
+Then (Expect header to appear and the columns):
+  Assert getline(1) ==# "Space Jam board", "No header found" 
+  Assert getline(2) ==# "=========", "No underlining found"
+
+  " Find the TODO category
+  /TO\ DO
+  Assert getline(".") =~# "TO DO:", "No To Do section"
+  normal! j 
+  Assert getline(".") ==# "------", "No underlining for To Do section"
+
+  " Make sure there is at least an issue properly formatted 
+  normal! j
+  Assert getline(".") =~# '\v^TEST\-\d+\s*.*$', "No issue in To Do"


### PR DESCRIPTION
Support spaced board names. Call it with `JiraVimBoardOpen Space Jam`, don't add quotes around the board name.

Fixes #47 