### PR TITLE
Adding pagination when fetching boards

### DIFF
--- a/python/common/connection.py
+++ b/python/common/connection.py
@@ -81,7 +81,6 @@ class Connection:
             board_hash[bName] = v
         self.__board_conf_hash = board_hash
 
-
     def getBaseUrl(self):
         """
         Getter for the base url

--- a/python/common/connection.py
+++ b/python/common/connection.py
@@ -70,7 +70,6 @@ class Connection:
             lastPage = rawBoardList["isLast"]
             # keep requesting boards until all are returned
             reqStr = "%s?startAt=%s" % (initReq, str(rawBoardList["startAt"] + rawBoardList["maxResults"]))
-    
         for v in boardList:
             # The board name in v comes as "<boardName> board"
             matches = re.match(r"\A([\s\w]+)\s[Bb]oard\Z", v["name"])


### PR DESCRIPTION
## Issue
https://github.com/paulkass/jira-vim/issues/52

## Description
I noticed when Jira contains a large number of boards the current board lookup logic doesn't catch boards that are outside the first page of request. This logic handles the ability to paginate through all boards and then performs a look up.

The downside of this (which applies to my case), if the board is pretty far into the pagination it takes longer to load since it has to go through all the pages until it finds it.

I've never written Python so feel free to make edits to make it fit the workflow better or comment what you'd like done differently and I can make them myself. Whatever works best for you 😄 